### PR TITLE
Fix validation for data objects

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/CreateOrgRequest.java
+++ b/src/main/java/iudx/aaa/server/apiserver/CreateOrgRequest.java
@@ -33,9 +33,17 @@ public class CreateOrgRequest {
     this.url = url;
   }
 
-  public CreateOrgRequest(JsonObject json) {
+  public static CreateOrgRequest validatedObj(JsonObject json) {
+    return new CreateOrgRequest(validateJsonObject(json));
+  }
 
-    CreateOrgRequestConverter.fromJson(validateJsonObject(json), this);
+  /**
+   * <b>Do not use this constructor for creating object.
+   * Use validatedObj function</b>
+   * @param json
+   */
+  public CreateOrgRequest(JsonObject json) {
+    CreateOrgRequestConverter.fromJson(json, this);
   }
 
   public JsonObject toJson() {
@@ -44,7 +52,7 @@ public class CreateOrgRequest {
     return obj;
   }
 
-  private JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
+  private static JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
     if (!json.containsKey("name") || !(json.getValue("name") instanceof String)) {
       throw new IllegalArgumentException("'name' is required");
     }

--- a/src/main/java/iudx/aaa/server/apiserver/RegistrationRequest.java
+++ b/src/main/java/iudx/aaa/server/apiserver/RegistrationRequest.java
@@ -29,9 +29,17 @@ public class RegistrationRequest {
     this.roles = roles;
   }
 
-  public RegistrationRequest(JsonObject json) {
+  static public RegistrationRequest validatedObj(JsonObject json) {
+    return new RegistrationRequest(validateJsonObject(json));
+  }
 
-    RegistrationRequestConverter.fromJson(validateJsonObject(json), this);
+  /**
+   * <b>Do not use this constructor for creating object.
+   * Use validatedObj function</b>
+   * @param json
+   */
+  public RegistrationRequest(JsonObject json) {
+    RegistrationRequestConverter.fromJson(json, this);
   }
 
   public JsonObject toJson() {
@@ -56,7 +64,7 @@ public class RegistrationRequest {
     this.orgId = UUID.fromString(orgId);
   }
 
-  private JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
+  private static JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
 
     if (!json.containsKey("roles") || !(json.getValue("roles") instanceof JsonArray)) {
       throw new IllegalArgumentException("'roles' array is required");

--- a/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
+++ b/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
@@ -28,9 +28,17 @@ public class UpdateProfileRequest {
     this.roles = roles;
   }
 
-  public UpdateProfileRequest(JsonObject json) {
+  public static UpdateProfileRequest validatedObj(JsonObject json) {
+    return new UpdateProfileRequest(validateJsonObject(json));
+  }
 
-    UpdateProfileRequestConverter.fromJson(validateJsonObject(json), this);
+  /**
+   * <b>Do not use this constructor for creating object.
+   * Use validatedObj function</b>
+   * @param json
+   */
+  public UpdateProfileRequest(JsonObject json) {
+    UpdateProfileRequestConverter.fromJson(json, this);
   }
 
   public JsonObject toJson() {
@@ -47,7 +55,7 @@ public class UpdateProfileRequest {
     this.orgId = UUID.fromString(orgId);
   }
 
-  private JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
+  private static JsonObject validateJsonObject(JsonObject json) throws IllegalArgumentException {
 
     if (!json.containsKey("roles") || !(json.getValue("roles") instanceof JsonArray)) {
       throw new IllegalArgumentException("'roles' array is required");

--- a/src/test/java/iudx/aaa/server/admin/CreateOrganizationTest.java
+++ b/src/test/java/iudx/aaa/server/admin/CreateOrganizationTest.java
@@ -168,32 +168,32 @@ public class CreateOrganizationTest {
   void validations(VertxTestContext testContext) {
 
     JsonObject empty = new JsonObject();
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(empty));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(empty));
 
     JsonObject invalidUrl = new JsonObject().put("url", new JsonArray());
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(invalidUrl));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(invalidUrl));
 
     JsonObject invalidName = new JsonObject().put("name", new JsonArray());
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(invalidName));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(invalidName));
 
     JsonObject missingUrl = new JsonObject().put("name", "");
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(missingUrl));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(missingUrl));
 
     JsonObject blank = new JsonObject().put("name", "").put("url", "");
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(blank));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(blank));
 
     JsonObject longName = new JsonObject().put("name", RandomStringUtils.randomAlphabetic(101))
         .put("url", RandomStringUtils.randomAlphabetic(10));
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(longName));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(longName));
 
     JsonObject specialCharName =
         new JsonObject().put("name", RandomStringUtils.randomAlphabetic(10) + "@").put("url",
             RandomStringUtils.randomAlphabetic(10));
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(specialCharName));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(specialCharName));
 
     JsonObject longUrl = new JsonObject().put("url", RandomStringUtils.randomAlphabetic(101))
         .put("name", RandomStringUtils.randomAlphabetic(10));
-    assertThrows(IllegalArgumentException.class, () -> new CreateOrgRequest(longUrl));
+    assertThrows(IllegalArgumentException.class, () -> CreateOrgRequest.validatedObj(longUrl));
 
     testContext.completeNow();
   }
@@ -204,7 +204,7 @@ public class CreateOrganizationTest {
     JsonObject userJson = adminAuthUser.result();
 
     JsonObject json = new JsonObject().put("url", "foo.bar").put("name", "bar");
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .name(userJson.getString("firstName"), userJson.getString("lastName"))
         .roles(List.of(Roles.ADMIN)).build();
@@ -225,7 +225,7 @@ public class CreateOrganizationTest {
     JsonObject userJson = adminOtherUser.result();
 
     JsonObject json = new JsonObject().put("url", "foo.bar").put("name", "bar");
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .userId(userJson.getString("userId")).roles(List.of(Roles.ADMIN))
         .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
@@ -246,7 +246,7 @@ public class CreateOrganizationTest {
     JsonObject userJson = consumerUser.result();
 
     JsonObject json = new JsonObject().put("url", "foo.bar").put("name", "bar");
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .userId(userJson.getString("userId")).roles(List.of(Roles.CONSUMER))
         .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
@@ -275,7 +275,7 @@ public class CreateOrganizationTest {
     Checkpoint specialChars = testContext.checkpoint();
 
     JsonObject json = new JsonObject().put("url", "https://example.com").put("name", "bar");
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
@@ -286,7 +286,7 @@ public class CreateOrganizationTest {
         })));
 
     json.clear().put("url", "example.com/path/1/2").put("name", "bar");
-    request = new CreateOrgRequest(json);
+    request = CreateOrgRequest.validatedObj(json);
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
@@ -297,7 +297,7 @@ public class CreateOrganizationTest {
         })));
 
     json.clear().put("url", "example.abcd").put("name", "bar");
-    request = new CreateOrgRequest(json);
+    request = CreateOrgRequest.validatedObj(json);
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
@@ -308,7 +308,7 @@ public class CreateOrganizationTest {
         })));
 
     json.clear().put("url", "example#@.abcd").put("name", "bar");
-    request = new CreateOrgRequest(json);
+    request = CreateOrgRequest.validatedObj(json);
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
@@ -328,7 +328,7 @@ public class CreateOrganizationTest {
     String url = name + ".com";
 
     JsonObject json = new JsonObject().put("url", url).put("name", name);
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .userId(userJson.getString("userId")).roles(List.of(Roles.ADMIN))
         .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
@@ -356,7 +356,7 @@ public class CreateOrganizationTest {
     String url = name + ".com";
 
     JsonObject json = new JsonObject().put("url", url).put("name", name);
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .userId(userJson.getString("userId")).roles(List.of(Roles.ADMIN))
         .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
@@ -398,10 +398,10 @@ public class CreateOrganizationTest {
     String url = "mail." + mainDomain;
 
     JsonObject json = new JsonObject().put("url", url).put("name", name);
-    CreateOrgRequest request = new CreateOrgRequest(json);
+    CreateOrgRequest request = CreateOrgRequest.validatedObj(json);
 
     json.clear().put("url", "subdomain." + url).put("name", name);
-    CreateOrgRequest requestSub = new CreateOrgRequest(json);
+    CreateOrgRequest requestSub = CreateOrgRequest.validatedObj(json);
 
     User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
         .userId(userJson.getString("userId")).roles(List.of(Roles.ADMIN))

--- a/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
@@ -123,43 +123,47 @@ public class CreateUserTest {
   void validations(VertxTestContext testContext) {
 
     JsonObject empty = new JsonObject();
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(empty));
+    assertThrows(IllegalArgumentException.class, () -> RegistrationRequest.validatedObj(empty));
 
     JsonObject invalidRole = new JsonObject().put("roles", new JsonArray().add("hello"));
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(invalidRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> RegistrationRequest.validatedObj(invalidRole));
 
     JsonObject adminRole = new JsonObject().put("roles", new JsonArray().add("admin"));
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(adminRole));
+    assertThrows(IllegalArgumentException.class, () -> RegistrationRequest.validatedObj(adminRole));
 
     JsonObject stringRole = new JsonObject().put("roles", "admin");
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(stringRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> RegistrationRequest.validatedObj(stringRole));
 
     JsonObject badRoleArr =
         new JsonObject().put("roles", new JsonArray().add(1).add(new JsonObject()));
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(badRoleArr));
+    assertThrows(IllegalArgumentException.class,
+        () -> RegistrationRequest.validatedObj(badRoleArr));
 
     JsonObject invalidPhone =
         new JsonObject().put("roles", new JsonArray().add("consumer")).put("phone", "665544");
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(invalidPhone));
+    assertThrows(IllegalArgumentException.class,
+        () -> RegistrationRequest.validatedObj(invalidPhone));
 
     JsonObject numPhone =
         new JsonObject().put("roles", new JsonArray().add("consumer")).put("phone", 9845598);
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(numPhone));
+    assertThrows(IllegalArgumentException.class, () -> RegistrationRequest.validatedObj(numPhone));
 
     JsonObject orgNum =
         new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId", 1234);
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(orgNum));
+    assertThrows(IllegalArgumentException.class, () -> RegistrationRequest.validatedObj(orgNum));
 
     JsonObject orgArr = new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId",
         new JsonArray());
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(orgArr));
+    assertThrows(IllegalArgumentException.class, () -> RegistrationRequest.validatedObj(orgArr));
 
     JsonObject orgInvalid = new JsonObject().put("roles", new JsonArray().add("provider"))
         .put("orgId", "107f8479-e767-4760-ac5f-d4518ebe3a8");
-    assertThrows(IllegalArgumentException.class, () -> new RegistrationRequest(orgInvalid));
+    assertThrows(IllegalArgumentException.class,
+        () -> RegistrationRequest.validatedObj(orgInvalid));
     testContext.completeNow();
   }
-
 
   @Test
   @DisplayName("Test successful consumer registration")
@@ -173,7 +177,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("Consumer")).put("phone", "9989989980");
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -215,7 +219,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq = new JsonObject().put("roles", new JsonArray().add("provider"))
         .put("orgId", orgId).put("phone", "9989989980");
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -256,9 +260,9 @@ public class CreateUserTest {
     Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
-    JsonObject jsonReq = new JsonObject().put("roles", new JsonArray().add("delegate"))
-        .put("orgId", orgId);
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    JsonObject jsonReq =
+        new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId", orgId);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -302,7 +306,7 @@ public class CreateUserTest {
     JsonObject jsonReq = new JsonObject()
         .put("roles", new JsonArray().add("delegate").add("provider").add("consumer"))
         .put("orgId", orgId).put("phone", "9989989980");
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -311,7 +315,7 @@ public class CreateUserTest {
           assertEquals(201, response.getInteger("status"));
 
           JsonObject result = response.getJsonObject("results");
-          
+
           assertEquals(Constants.URN_SUCCESS, response.getString("type"));
           assertEquals(Constants.SUCC_TITLE_CREATED_USER + Constants.PROVIDER_PENDING_MESG,
               response.getString("title"));
@@ -347,7 +351,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId", orgId);
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -373,7 +377,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("provider").add("delegate"));
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -400,7 +404,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId", orgId);
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
     registrationService.createUser(request, user,
@@ -427,7 +431,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId", orgId);
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -464,7 +468,7 @@ public class CreateUserTest {
 
     JsonObject jsonReq =
         new JsonObject().put("roles", new JsonArray().add("provider")).put("orgId", orgId);
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 
@@ -489,7 +493,7 @@ public class CreateUserTest {
     Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.failedFuture("fail"));
 
     JsonObject jsonReq = new JsonObject().put("roles", new JsonArray().add("consumer"));
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
+    RegistrationRequest request = RegistrationRequest.validatedObj(jsonReq);
 
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
 

--- a/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
@@ -154,35 +154,41 @@ public class UpdateUserTest {
   void validations(VertxTestContext testContext) {
 
     JsonObject empty = new JsonObject();
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(empty));
+    assertThrows(IllegalArgumentException.class, () -> UpdateProfileRequest.validatedObj(empty));
 
     JsonObject invalidRole = new JsonObject().put("roles", new JsonArray().add("hello"));
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(invalidRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(invalidRole));
 
     JsonObject adminRole = new JsonObject().put("roles", new JsonArray().add("admin"));
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(adminRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(adminRole));
 
     JsonObject stringRole = new JsonObject().put("roles", "admin");
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(stringRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(stringRole));
 
     JsonObject badRoleArr =
         new JsonObject().put("roles", new JsonArray().add(1).add(new JsonObject()));
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(badRoleArr));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(badRoleArr));
 
     JsonObject orgNum =
         new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId", 1234);
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(orgNum));
+    assertThrows(IllegalArgumentException.class, () -> UpdateProfileRequest.validatedObj(orgNum));
 
     JsonObject orgArr = new JsonObject().put("roles", new JsonArray().add("consumer")).put("orgId",
         new JsonArray());
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(orgArr));
+    assertThrows(IllegalArgumentException.class, () -> UpdateProfileRequest.validatedObj(orgArr));
 
     JsonObject orgInvalid = new JsonObject().put("roles", new JsonArray().add("delegate"))
         .put("orgId", "107f8479-e767-4760-ac5f-d4518ebe3a8");
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(orgInvalid));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(orgInvalid));
 
     JsonObject providerRole = new JsonObject().put("roles", new JsonArray().add("provider"));
-    assertThrows(IllegalArgumentException.class, () -> new UpdateProfileRequest(providerRole));
+    assertThrows(IllegalArgumentException.class,
+        () -> UpdateProfileRequest.validatedObj(providerRole));
 
     testContext.completeNow();
   }
@@ -195,7 +201,7 @@ public class UpdateUserTest {
     JsonObject req = new JsonObject().put("orgId", orgIdFut.result().toString()).put("roles",
         new JsonArray().add("delegate"));
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture("email@gmail.com"));
 
@@ -213,7 +219,7 @@ public class UpdateUserTest {
   void consumerNoOrgId(VertxTestContext testContext) {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate"));
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.CONSUMER);
     Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
@@ -248,7 +254,7 @@ public class UpdateUserTest {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
         UUID.randomUUID().toString());
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.CONSUMER);
     Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
@@ -284,7 +290,7 @@ public class UpdateUserTest {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
         orgIdFut.result().toString());
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.CONSUMER);
     Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
@@ -321,7 +327,7 @@ public class UpdateUserTest {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
         orgIdFut.result().toString());
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.CONSUMER);
     Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
@@ -383,7 +389,7 @@ public class UpdateUserTest {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer").add("delegate"))
         .put("orgId", orgIdFut.result().toString());
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.DELEGATE, Roles.PROVIDER);
     Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
@@ -424,7 +430,7 @@ public class UpdateUserTest {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer").add("delegate"));
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     Map<Roles, RoleStatus> prov = new HashMap<Roles, RoleStatus>();
     prov.put(Roles.PROVIDER, RoleStatus.PENDING);
@@ -486,7 +492,7 @@ public class UpdateUserTest {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer"));
 
-    UpdateProfileRequest request = new UpdateProfileRequest(req);
+    UpdateProfileRequest request = UpdateProfileRequest.validatedObj(req);
 
     List<Roles> roles = List.of(Roles.PROVIDER);
     Map<Roles, RoleStatus> prov = new HashMap<Roles, RoleStatus>();


### PR DESCRIPTION
- Previously, validation performed in JsonObject constructor. This resulted in validation being triggered
when the object is serialized/deserialized on for proxy
- Created new static function to perform validation instead, change JsonObject constructor to only create
not validate