### PR TITLE
Add registration + admin routes to ApiServerVerticle +

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/RoleStatus.java
+++ b/src/main/java/iudx/aaa/server/apiserver/RoleStatus.java
@@ -1,8 +1,23 @@
 package iudx.aaa.server.apiserver;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Enum that defines valid status a role can be in.
  */
 public enum RoleStatus {
   PENDING, APPROVED, REJECTED;
+
+  static List<String> roleStatusAsStrings =
+      Arrays.stream(RoleStatus.values()).map(r -> r.name()).collect(Collectors.toList());
+
+  /* function to check if a string is part of the enum without using try/catch */
+  public static boolean exists(String str) {
+    if (roleStatusAsStrings.contains(str)) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
@@ -11,7 +11,7 @@ public class Constants {
   public static final String HEADER_REFERER = "Referer";
   public static final String HEADER_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
   public static final String HEADER_OPTIONS = "options";
-  
+
   /* Configuration & related */
   public static final String DATABASE_IP = "databaseIP";
   public static final String DATABASE_PORT = "databasePort";
@@ -32,14 +32,20 @@ public class Constants {
   // Accept Headers and CORS
   public static final String MIME_APPLICATION_JSON = "application/json";
   public static final String MIME_TEXT_HTML = "text/html";
-  
+
   public static final String NIL_UUID = "00000000-0000-0000-0000-000000000000";
-  
+
   /* API Server Routes */
-  public static final String API_TOKEN="/auth/v1/token";
-  public static final String API_INTROSPECT_TOKEN="/auth/v1/interospect";
-  public static final String API_REVOKE_TOKEN="/auth/v1/token/revoke";
-  
+  public static final String API_TOKEN = "/auth/v1/token";
+  public static final String API_INTROSPECT_TOKEN = "/auth/v1/introspect";
+  public static final String API_REVOKE_TOKEN = "/auth/v1/token/revoke";
+  public static final String API_USER_PROFILE = "/auth/v1/user/profile";
+  public static final String API_ORGANIZATION = "/auth/v1/organizations";
+  public static final String API_ADMIN_PROVIDER_REG = "/auth/v1/admin/provider/registrations";
+
+  /* Query Params */
+  public static final String QUERY_FILTER = "filter";
+
   /* Response Messages */
   public static final String URN_SUCCESS = "urn:dx:as:Success";
   public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
@@ -48,16 +54,18 @@ public class Constants {
   public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
   public static final String URN_INVALID_AUTH_TOKEN = "urn:dx:as:InvalidAuthenticationToken";
   public static final String URN_MISSING_AUTH_TOKEN = "urn:dx:as:MissingAuthenticationToken";
-  
+
   public static final String TOKEN_FAILED = "Token authentication failed";
   public static final String MISSING_TOKEN = "Missing accessToken";
   public static final String INTERNAL_SVR_ERR = "Internal server error";
   public static final String MISSING_TOKEN_CLIENT = "Missing auth details";
   public static final String INVALID_JSON = "Invalid Json";
-  
+  public static final String ERR_TITLE_BAD_REQUEST = "Missing or malformed parameters";
+  public static final String ERR_DETAIL_BAD_FILTER = "Invalid 'filter' value";
+
   public static final String LOG_FAILED_DISCOVERY = "Fail: Unable to discover keycloak instance; ";
-  
-  /* General */ 
+
+  /* General */
   public static final String NAME = "name";
   public static final String SUB = "sub";
   public static final String ID = "id";
@@ -70,20 +78,25 @@ public class Constants {
   public static final String JWT_LEEWAY = "jwtLeeway";
   public static final String STATUS = "status";
   public static final String SSL = "ssl";
-  
-  
+
+  /* Compose failure due to invalid token */
+  public static final String INVALID_TOKEN_FAILED_COMPOSE = "INVALID_TOKEN";
+
   /* SQL Queries */
   public static final String DB_SCHEMA = "test";
-  public static final String SQL_GET_USER_ROLES = "SELECT u.id, uc.client_id, array_agg(r.role) as roles \n" + 
-      "FROM (select id from " + DB_SCHEMA + ".users where keycloak_id = $1) u \n" + 
-      "LEFT JOIN " + DB_SCHEMA + ".roles r ON u.id = r.user_id \n" + 
-      "LEFT JOIN " + DB_SCHEMA + ".user_clients uc ON u.id = uc.user_id \n" +
-      "where r.status='APPROVED' GROUP BY u.id, uc.client_id";
-  
-  public static final String SQL_GET_KID_ROLES = "SELECT u.id, q.keycloak_id as kid, client_secret, array_agg(r.role) as roles\n" + 
-      "FROM (select user_id as id, client_secret from " + DB_SCHEMA + ".user_clients where client_id = $1) u\n" + 
-      "LEFT JOIN " + DB_SCHEMA + ".roles r ON u.id = r.user_id\n" + 
-      "LEFT JOIN " + DB_SCHEMA + ".users q ON u.id = q.id\n" + 
-      "where r.status='APPROVED' GROUP BY u.id, client_secret, keycloak_id";
+  public static final String SQL_GET_USER_ROLES =
+      "SELECT u.id, uc.client_id, array_agg(r.role) as roles \n" + "FROM (select id from "
+          + DB_SCHEMA + ".users where keycloak_id = $1) u \n" + "LEFT JOIN " + DB_SCHEMA
+          + ".roles r ON u.id = r.user_id \n" + "LEFT JOIN " + DB_SCHEMA
+          + ".user_clients uc ON u.id = uc.user_id \n"
+          + "where r.status='APPROVED' GROUP BY u.id, uc.client_id";
+
+  public static final String SQL_GET_KID_ROLES =
+      "SELECT u.id, q.keycloak_id as kid, client_secret, array_agg(r.role) as roles\n"
+          + "FROM (select user_id as id, client_secret from " + DB_SCHEMA
+          + ".user_clients where client_id = $1) u\n" + "LEFT JOIN " + DB_SCHEMA
+          + ".roles r ON u.id = r.user_id\n" + "LEFT JOIN " + DB_SCHEMA
+          + ".users q ON u.id = q.id\n"
+          + "where r.status='APPROVED' GROUP BY u.id, client_secret, keycloak_id";
 
 }

--- a/src/main/java/iudx/aaa/server/apiserver/util/RequestAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/RequestAuthentication.java
@@ -11,6 +11,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
@@ -39,13 +40,13 @@ import static iudx.aaa.server.token.Constants.URN_INVALID_INPUT;
  *
  */
 public class RequestAuthentication implements Handler<RoutingContext> {
-  
+
   private static final Logger LOGGER = LogManager.getLogger(RequestAuthentication.class);
   private Vertx vertx;
   private PgPool pgPool;
   private JsonObject keycloakOptions;
   private OAuth2Auth keycloak;
-  
+
   public RequestAuthentication(Vertx vertx, PgPool pgPool, JsonObject keycloakOptions) {
     this.vertx = vertx;
     this.pgPool = pgPool;
@@ -57,7 +58,20 @@ public class RequestAuthentication implements Handler<RoutingContext> {
   public void handle(RoutingContext routingContext) {
 
     MultiMap headers = routingContext.request().headers();
-    String token = headers.get(HEADER_TOKEN);    
+    String token;
+    String authorization = headers.get(HttpHeaders.AUTHORIZATION);
+
+    if (authorization != null && !authorization.isBlank()) {
+      String[] contents = authorization.split(" ");
+      if (contents.length != 2 || !contents[0].equals("Bearer")) {
+        token = null;
+      } else {
+        token = contents[1];
+      }
+    } else {
+      token = null;
+    }
+
     iudx.aaa.server.apiserver.User.UserBuilder user = new UserBuilder();
 
     /* Handles OIDC Token Flow */
@@ -73,47 +87,56 @@ public class RequestAuthentication implements Handler<RoutingContext> {
         LOGGER.info("Info: JWT authenticated");
         User cred = User.create(new JsonObject().put("access_token", token));
         return keycloak.userInfo(cred);
+        /*
+         * Add extra onFailure as userinfo may not respect leeway. Token may pass authentication,
+         * but may fail userinfo auth
+         */
+      }).onFailure(authHandler -> {
+        Response rs = new ResponseBuilder().status(401).type(URN_INVALID_AUTH_TOKEN)
+            .title(TOKEN_FAILED).detail(authHandler.getLocalizedMessage()).build();
+        routingContext.fail(new Throwable(rs.toJsonString()));
+        routingContext.end();
 
       }).compose(mapper -> {
         LOGGER.debug("Info: UserInfo fetched");
         String kId = mapper.getString(SUB);
         user.keycloakId(kId);
-        
-        String[] name = mapper.getString(NAME," ").split(" ");
+
+        String[] name = mapper.getString(NAME, " ").split(" ");
         if (name.length == 2) {
           user.name(name[0], name[1]);
         } else {
           user.name(String.join(" ", name).strip(), null);
         }
-        
+
         return pgSelectUser(SQL_GET_USER_ROLES, kId);
-        
+
       }).onComplete(kcHandler -> {
         if (kcHandler.succeeded()) {
           JsonObject result = kcHandler.result();
-          
+
           if (!result.isEmpty()) {
             user.userId(result.getString(ID));
             user.roles(processRoles(result.getJsonArray(ROLES)));
           }
-          
+
           routingContext.put(CLIENT_ID, result.getString("client_id"));
           routingContext.put(USER, user.build()).next();
-        } else if(kcHandler.failed()) {
+        } else if (kcHandler.failed()) {
           LOGGER.error("Fail: Request validation and authentication; " + kcHandler.cause());
-          Response rs = new ResponseBuilder().status(500)
-              .title(INTERNAL_SVR_ERR).detail(kcHandler.cause().getLocalizedMessage()).build();
+          Response rs = new ResponseBuilder().status(500).title(INTERNAL_SVR_ERR)
+              .detail(kcHandler.cause().getLocalizedMessage()).build();
           routingContext.fail(new Throwable(rs.toJsonString()));
         }
       });
-      
+
       /* Handles ClientId Flow */
-    } else if(headers.contains(CLIENT_ID) && headers.contains(CLIENT_SECRET)){
+    } else if (headers.contains(CLIENT_ID) && headers.contains(CLIENT_SECRET)) {
       String clientId = headers.get(CLIENT_ID);
       String clientSecret = headers.get(CLIENT_SECRET);
-      
-      if(clientId != null && !clientId.isBlank()) {
-        
+
+      if (clientId != null && !clientId.isBlank()) {
+
         pgSelectUser(SQL_GET_KID_ROLES, clientId).onComplete(dbHandler -> {
           if (dbHandler.failed()) {
             LOGGER.error(LOG_DB_ERROR + dbHandler.cause());
@@ -128,7 +151,7 @@ public class RequestAuthentication implements Handler<RoutingContext> {
 
           JsonObject result = dbHandler.result();
           String dbClientSecret = result.getString("client_secret");
-          
+
           /* Validating clientSecret hash */
           boolean valid = false;
           try {
@@ -149,39 +172,35 @@ public class RequestAuthentication implements Handler<RoutingContext> {
             routingContext.fail(new Throwable(resp.toJson().toString()));
             return;
           }
-          
-          user.keycloakId(result.getString(KID))
-              .userId(result.getString(ID))
+
+          user.keycloakId(result.getString(KID)).userId(result.getString(ID))
               .roles(processRoles(result.getJsonArray(ROLES)));
-          
+
           routingContext.put(CLIENT_ID, clientId);
           routingContext.put(USER, user.build()).next();
         });
       }
     } else {
-      LOGGER.error("Fail: {}; {}",MISSING_TOKEN_CLIENT,"null clientId/token");
+      LOGGER.error("Fail: {}; {}", MISSING_TOKEN_CLIENT, "null clientId/token");
       Response rs = new ResponseBuilder().status(401).type(URN_MISSING_AUTH_TOKEN)
           .title(MISSING_TOKEN_CLIENT).detail(MISSING_TOKEN_CLIENT).build();
       routingContext.fail(new Throwable(rs.toJsonString()));
     }
   }
-  
+
   /**
    * Creates KeyCloack provider using configurations.
    */
   public void keyCloackAuth() {
     String site = keycloakOptions.getString(SITE);
     String realm = site.substring(site.lastIndexOf('/') + 1);
-    
+
     /* Options for OAuth2, KeyCloack. */
-    OAuth2Options options = new OAuth2Options()
-        .setFlow(OAuth2FlowType.CLIENT)
+    OAuth2Options options = new OAuth2Options().setFlow(OAuth2FlowType.CLIENT)
         .setClientID(keycloakOptions.getString(CLIENT_ID))
-        .setClientSecret(keycloakOptions.getString(CLIENT_SECRET))
-        .setTenant(realm)
-        .setSite(site)
+        .setClientSecret(keycloakOptions.getString(CLIENT_SECRET)).setTenant(realm).setSite(site)
         .setJWTOptions(new JWTOptions().setLeeway(keycloakOptions.getInteger(JWT_LEEWAY)));
-    
+
     options.getHttpClientOptions().setSsl(true).setVerifyHost(false).setTrustAll(true);
 
     /* Discovers the keycloack instance */
@@ -192,10 +211,11 @@ public class RequestAuthentication implements Handler<RoutingContext> {
         LOGGER.error(LOG_FAILED_DISCOVERY + discover.cause());
       }
     });
-  } 
-  
+  }
+
   /**
    * Handles database queries.
+   * 
    * @param sql query
    * @param if of the element
    * @return Future promise which is JsonObject
@@ -215,18 +235,17 @@ public class RequestAuthentication implements Handler<RoutingContext> {
         }));
     return promise.future();
   }
-  
+
   /**
    * Creates Roles enum.
+   * 
    * @param role
    * @return List having Roles
    */
   public List<Roles> processRoles(JsonArray role) {
-    List<Roles> roles = role.stream()
-        .filter(a -> Roles.exists(a.toString()))
-        .map(a -> Roles.valueOf(a.toString()))
-        .collect(Collectors.toList());
-    
+    List<Roles> roles = role.stream().filter(a -> Roles.exists(a.toString()))
+        .map(a -> Roles.valueOf(a.toString())).collect(Collectors.toList());
+
     return roles;
   }
 }


### PR DESCRIPTION
- Add additional onFailure to token request in RequestAuthentication
- *Change 'token' header to 'Authorization: Bearer ...' header*
- Add IllegalArgumentException to FailureHandler to handle DataObject validation exceptions
- Add `exists` function to RoleStatus enum for query filter validation for getProviderRegistration API
- change introspect API endpoint
- formatting