### PR TITLE
Make UpdateProviderRegistrationStatus API use createPolicy to set aut…

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/createPolicy.java
+++ b/src/main/java/iudx/aaa/server/policy/createPolicy.java
@@ -111,7 +111,6 @@ public class createPolicy {
       Map<String, UUID> ownerId,
       User user) {
     Promise<Boolean> p = Promise.promise();
-
     Future<List<Tuple>> tuples = createTuple(req, resourceId, ownerId, user);
 
     Future<List<Tuple>> checkDuplicate = tuples.compose(this::checkExistingPolicy);
@@ -157,12 +156,11 @@ public class createPolicy {
           expiryTime = LocalDateTime.parse(expTime, DateTimeFormatter.ISO_DATE_TIME);
         else {
           if (itemType.equals(itemTypes.RESOURCE_SERVER.toString()))
-            expiryTime =
-                LocalDateTime.now(ZoneOffset.UTC)
-                    .plusMonths(options.getInteger("adminPolicyExpiry"));
+            expiryTime = LocalDateTime.now(ZoneOffset.UTC)
+                .plusMonths(Integer.parseInt(options.getString("adminPolicyExpiry")));
           else
-            expiryTime =
-                LocalDateTime.now(ZoneOffset.UTC).plusMonths(options.getInteger("PolicyExpiry"));
+            expiryTime = LocalDateTime.now(ZoneOffset.UTC)
+                .plusMonths(Integer.parseInt(options.getString("policyExpiry")));
         }
         JsonObject constraints = obj.getConstraints();
         tuples.add(Tuple.of(userId, itemId, itemType, providerId, status, expiryTime, constraints));


### PR DESCRIPTION
…h admin policies for approved providers

- Instead of using a separate method, use createPolicy as an auth admin to set
the policies for approved
- Reorder transaction future to rollback if createPolicy service fails
- Add test to check for transaction rollback
- Fix default policy time config fetch in `createPolicy.java`