### PR TITLE
Update maven-shade build to fix Keycloak fat JAR bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,9 +301,7 @@
 									</manifestEntries>
 								</transformer>
 								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
-									</resource>
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
 								</transformer>
 							</transformers>
 							<artifactSet></artifactSet>
@@ -337,9 +335,7 @@
 									</manifestEntries>
 								</transformer>
 								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
-									</resource>
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
 								</transformer>
 							</transformers>
 							<artifactSet></artifactSet>


### PR DESCRIPTION
- With the previous config, the fat JAR was generated successfully when `mvn package` is run
but an error was being thrown by the Keycloak admin client whenever it was called
- This change seems to fix the issue