### PR TITLE
Bugfix - make orgId always required for adding delegate role

### DIFF
--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -417,9 +417,8 @@ public class RegistrationServiceImpl implements RegistrationService {
     Future<String> email = kc.getEmailId(user.getKeycloakId());
     Future<String> checkOrgRequired;
 
-    /* currently, org_id is needed only when a consumer wants to register as a delegate */
-    if (registeredRoles.containsAll(List.of(Roles.CONSUMER))
-        && requestedRoles.containsAll(List.of(Roles.DELEGATE))) {
+    /* orgId is needed always for delegate reg, even if the user has registered for provider role */
+    if (requestedRoles.contains(Roles.DELEGATE)) {
       if (orgId.toString().equals(NIL_UUID)) {
         Response r = new ResponseBuilder().status(400).type(URN_MISSING_INFO)
             .title(ERR_TITLE_ORG_ID_REQUIRED).detail(ERR_DETAIL_ORG_ID_REQUIRED).build();


### PR DESCRIPTION
Previously, orgId was only required when the user had an
approved Consumer role and was requesting to be a delegate. This did not
consider that the user may have had a pending/rejected provider role. To
simplify this flow, we now always need orgId if delegate role
has been requested and overwrite the orgId in the DB in case it was already there.