### PR TITLE
Change client secret to random string + SHA512 in DB

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -32,36 +32,49 @@ paths:
                     type: string
                     minLength: 1
                   results:
-                    type: array
-                    uniqueItems: true
-                    minItems: 1
-                    items:
-                      required:
-                        - accessToken
-                        - expiry
-                        - server
-                      properties:
-                        accessToken:
-                          type: string
-                          minLength: 1
-                        expiry:
-                          type: number
-                        server:
-                          type: string
-                          minLength: 1
+                    type: object
+                    properties:
+                      accessToken:
+                        type: string
+                        minLength: 1
+                      expiry:
+                        type: number
+                      server:
+                        type: string
+                        minLength: 1
+                    required:
+                      - accessToken
+                      - expiry
+                      - server
                 required:
                   - type
                   - title
                   - results
+                x-examples:
+                  example-1:
+                    type: 'urn:dx:as:Success'
+                    title: Token created
+                    results:
+                      accessToken: eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIzNDliNGI1NS0wMjUxLTQ5MGUtYmVlOS0wMGYzYTVkM2U2NDMiLCJpc3MiOiJhdXRoLnRlc3QuY29tIiwiYXVkIjoiZm9vYmFyLml1ZHguaW8iLCJleHAiOjE2MjY4MzY3ODQsImlhdCI6MTYyNjc5MzU4NCwiaWlkIjoicmc6ZXhhbXBsZS5jb20vNzllN2JmYTYyZmFkNmM3NjViYWM2OTE1NGMyZjI0Yzk0Yzk1MjIwYS9yZXNvdXJjZS1ncm91cCIsInJvbGUiOiJjb25zdW1lciIsImNvbnMiOnt9fQ.eAWKamrRdV4c1MPuoLU6j0bWB6iiM_of5F3LA-_DZGhyu_6aFP4cmCI1Y3ZN2ZRklOSGcrL5aHC8Ccga6dtTrg
+                      expiry: 1626836784
+                      server: foobar.iudx.io
               examples:
                 General Structure:
                   value:
                     type: 'urn:dx:as:Success'
                     title: Token created
                     results:
-                      - accessToken: eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIzNDliNGI1NS0wMjUxLTQ5MGUtYmVlOS0wMGYzYTVkM2U2NDMiLCJpc3MiOiJhdXRoLnRlc3QuY29tIiwiYXVkIjoiZm9vYmFyLml1ZHguaW8iLCJleHAiOjE2MjY4MzY3ODQsImlhdCI6MTYyNjc5MzU4NCwiaWlkIjoicmc6ZXhhbXBsZS5jb20vNzllN2JmYTYyZmFkNmM3NjViYWM2OTE1NGMyZjI0Yzk0Yzk1MjIwYS9yZXNvdXJjZS1ncm91cCIsInJvbGUiOiJjb25zdW1lciIsImNvbnMiOnt9fQ.eAWKamrRdV4c1MPuoLU6j0bWB6iiM_of5F3LA-_DZGhyu_6aFP4cmCI1Y3ZN2ZRklOSGcrL5aHC8Ccga6dtTrg
-                        expiry: 1626836784
-                        server: foobar.iudx.io
+                      accessToken: eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIzNDliNGI1NS0wMjUxLTQ5MGUtYmVlOS0wMGYzYTVkM2U2NDMiLCJpc3MiOiJhdXRoLnRlc3QuY29tIiwiYXVkIjoiZm9vYmFyLml1ZHguaW8iLCJleHAiOjE2MjY4MzY3ODQsImlhdCI6MTYyNjc5MzU4NCwiaWlkIjoicmc6ZXhhbXBsZS5jb20vNzllN2JmYTYyZmFkNmM3NjViYWM2OTE1NGMyZjI0Yzk0Yzk1MjIwYS9yZXNvdXJjZS1ncm91cCIsInJvbGUiOiJjb25zdW1lciIsImNvbnMiOnt9fQ.eAWKamrRdV4c1MPuoLU6j0bWB6iiM_of5F3LA-_DZGhyu_6aFP4cmCI1Y3ZN2ZRklOSGcrL5aHC8Ccga6dtTrg
+                      expiry: 1626836784
+                      server: foobar.iudx.io
+                example-1:
+                  value:
+                    type: string
+                    title: string
+                    results:
+                      accessToken: string
+                      expiry: 0
+                      server: string
           headers:
             Content-Type:
               schema:
@@ -133,10 +146,10 @@ paths:
           description: Keycloak Issued clientId
         - schema:
             type: string
-            format: uuid
-            maxLength: 36
-            pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
-            minLength: 36
+            maxLength: 40
+            pattern: '^[0-9a-f]{40}$'
+            minLength: 40
+            example: 73b66ab55ba4d07ea487310679aa0689b4bd2c9d
           in: header
           description: Keycloak Issued clientSecret
           name: clientSecret
@@ -199,6 +212,19 @@ paths:
               schema:
                 description: ''
                 type: object
+                x-examples:
+                  example-1:
+                    type: 'urn:dx:as:Success'
+                    title: Token authenticated
+                    results:
+                      sub: 129b4b55-0251-490e-bee9-00f3a5d3e632
+                      iss: auth.test.com
+                      aud: foobar.iudx.io
+                      exp: 1626837909
+                      iat: 1626794709
+                      iid: 'rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95210v/resource-group'
+                      role: consumer
+                      cons: {}
                 properties:
                   type:
                     type: string
@@ -207,42 +233,38 @@ paths:
                     type: string
                     minLength: 1
                   results:
-                    type: array
-                    uniqueItems: true
-                    minItems: 1
-                    items:
-                      type: object
-                      properties:
-                        sub:
-                          type: string
-                          minLength: 1
-                        iss:
-                          type: string
-                          minLength: 1
-                        aud:
-                          type: string
-                          minLength: 1
-                        exp:
-                          type: number
-                        iat:
-                          type: number
-                        iid:
-                          type: string
-                          minLength: 1
-                        role:
-                          type: string
-                          minLength: 1
-                        cons:
-                          type: object
-                      required:
-                        - sub
-                        - iss
-                        - aud
-                        - exp
-                        - iat
-                        - iid
-                        - role
-                        - cons
+                    type: object
+                    required:
+                      - sub
+                      - iss
+                      - aud
+                      - exp
+                      - iat
+                      - iid
+                      - role
+                      - cons
+                    properties:
+                      sub:
+                        type: string
+                        minLength: 1
+                      iss:
+                        type: string
+                        minLength: 1
+                      aud:
+                        type: string
+                        minLength: 1
+                      exp:
+                        type: number
+                      iat:
+                        type: number
+                      iid:
+                        type: string
+                        minLength: 1
+                      role:
+                        type: string
+                        minLength: 1
+                      cons:
+                        type: object
                 required:
                   - type
                   - title
@@ -253,14 +275,14 @@ paths:
                     type: 'urn:dx:as:Success'
                     title: Token authenticated
                     results:
-                      - sub: 129b4b55-0251-490e-bee9-00f3a5d3e632
-                        iss: auth.test.com
-                        aud: foobar.iudx.io
-                        exp: 1626837909
-                        iat: 1626794709
-                        iid: 'rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95210v/resource-group'
-                        role: consumer
-                        cons: {}
+                      sub: 129b4b55-0251-490e-bee9-00f3a5d3e632
+                      iss: auth.test.com
+                      aud: foobar.iudx.io
+                      exp: 1626837909
+                      iat: 1626794709
+                      iid: 'rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95210v/resource-group'
+                      role: consumer
+                      cons: {}
         '400':
           description: Invalid/missing information
           content:
@@ -517,7 +539,9 @@ paths:
                               minLength: 1
                             clientSecret:
                               type: string
-                              minLength: 1
+                              minLength: 40
+                              maxLength: 40
+                              pattern: '^[0-9a-f]{40}$'
                           required:
                             - clientName
                             - clientId
@@ -560,7 +584,7 @@ paths:
                       clients:
                         - clientName: default
                           clientId: 6d0b58c3-c0c4-48af-bca2-4f255c0e73a7
-                          clientSecret: a18cb9fc-06b3-4ae5-8220-86fc4e89a1a6
+                          clientSecret: 73b66ab55ba4d07ea487310679aa0689b4bd2c9d
                       email: ngoaf@chspomvjuq.com
                       phone: '9919967211'
                       organization:

--- a/pom.xml
+++ b/pom.xml
@@ -173,11 +173,6 @@
 			<artifactId>vertx-auth-jwt</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.69</version>
-		</dependency>
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>3.11.1</version>

--- a/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
@@ -16,13 +16,14 @@ import static iudx.aaa.server.token.Constants.LOG_DB_ERROR;
 import static iudx.aaa.server.token.Constants.LOG_UNAUTHORIZED;
 import static iudx.aaa.server.token.Constants.LOG_USER_SECRET;
 import static iudx.aaa.server.token.Constants.URN_INVALID_INPUT;
-import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -89,8 +90,10 @@ public class ClientAuthentication implements AuthenticationHandler{
           /* Validating clientSecret hash */
           boolean valid = false;
           try {
-            valid = OpenBSDBCrypt.checkPassword(dbClientSecret,
-                clientSecret.getBytes(StandardCharsets.UTF_8));
+            byte[] requestSecretHashed = DigestUtils.sha512(clientSecret);
+            byte[] dbSecretHashed = Hex.decodeHex(dbClientSecret.toCharArray());
+
+            valid = MessageDigest.isEqual(dbSecretHashed, requestSecretHashed);
           } catch (Exception e) {
             LOGGER.error(LOG_USER_SECRET + e.getLocalizedMessage());
             Response resp = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)

--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -32,10 +32,8 @@ public class Constants {
   public static final String KC_ADMIN_CLIENT_ID = "keycloakAdminClientId";
   public static final String KC_ADMIN_CLIENT_SEC = "keycloakAdminClientSecret";
   public static final String KC_ADMIN_POOLSIZE = "keycloakAdminPoolSize";
-
-  /* bcrypt parameters TODO move to common constants file */
-  public static final int BCRYPT_LOG_COST = 12;
-  public static final int BCRYPT_SALT_LEN = 16;
+  
+  public static final int CLIENT_SECRET_BYTES = 20; 
 
   /* Response fields */
   public static final String RESP_CLIENT_NAME = "clientName";

--- a/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.registration.Constants.CLIENT_SECRET_BYTES;
 import static iudx.aaa.server.registration.Constants.DEFAULT_CLIENT;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_NO_EXIST;
@@ -78,6 +79,8 @@ public class CreateUserTest {
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static final String UUID_REGEX =
       "^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$";
+  private static final int CLIENT_SECRET_HEX_LEN = CLIENT_SECRET_BYTES * 2;
+  private static final String CLIENT_SECRET_REGEX = "^[0-9a-f]{" + CLIENT_SECRET_HEX_LEN + "}$";
 
   static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
   static String url = name + ".com";
@@ -167,7 +170,7 @@ public class CreateUserTest {
 
           JsonObject client = result.getJsonArray("clients").getJsonObject(0);
           assertTrue(client.getString(RESP_CLIENT_ID).matches(UUID_REGEX));
-          assertTrue(client.getString(RESP_CLIENT_SC).matches(UUID_REGEX));
+          assertTrue(client.getString(RESP_CLIENT_SC).matches(CLIENT_SECRET_REGEX));
           assertEquals(client.getString(RESP_CLIENT_NAME), DEFAULT_CLIENT);
 
           testContext.completeNow();
@@ -210,7 +213,7 @@ public class CreateUserTest {
 
           JsonObject client = result.getJsonArray("clients").getJsonObject(0);
           assertTrue(client.getString(RESP_CLIENT_ID).matches(UUID_REGEX));
-          assertTrue(client.getString(RESP_CLIENT_SC).matches(UUID_REGEX));
+          assertTrue(client.getString(RESP_CLIENT_SC).matches(CLIENT_SECRET_REGEX));
           assertEquals(client.getString(RESP_CLIENT_NAME), DEFAULT_CLIENT);
 
           testContext.completeNow();
@@ -253,7 +256,7 @@ public class CreateUserTest {
 
           JsonObject client = result.getJsonArray("clients").getJsonObject(0);
           assertTrue(client.getString(RESP_CLIENT_ID).matches(UUID_REGEX));
-          assertTrue(client.getString(RESP_CLIENT_SC).matches(UUID_REGEX));
+          assertTrue(client.getString(RESP_CLIENT_SC).matches(CLIENT_SECRET_REGEX));
           assertEquals(client.getString(RESP_CLIENT_NAME), DEFAULT_CLIENT);
 
           testContext.completeNow();
@@ -302,7 +305,7 @@ public class CreateUserTest {
 
           JsonObject client = result.getJsonArray("clients").getJsonObject(0);
           assertTrue(client.getString(RESP_CLIENT_ID).matches(UUID_REGEX));
-          assertTrue(client.getString(RESP_CLIENT_SC).matches(UUID_REGEX));
+          assertTrue(client.getString(RESP_CLIENT_SC).matches(CLIENT_SECRET_REGEX));
           assertEquals(client.getString(RESP_CLIENT_NAME), DEFAULT_CLIENT);
 
           testContext.completeNow();

--- a/src/test/java/iudx/aaa/server/token/RequestPayload.java
+++ b/src/test/java/iudx/aaa/server/token/RequestPayload.java
@@ -21,7 +21,7 @@ public class RequestPayload {
   public static JsonArray roleList = new JsonArray("[\"delegate\",\"provider\"]");
   
   public static JsonObject validPayload = new JsonObject().put("clientId", "349b4b55-0251-490e-bee9-00f3a5d3e643")
-      .put("clientSecret","48434da1-411d-42d6-894a-557fd5b9965e")
+      .put("clientSecret","e980d5bda287fa4808f8b6d32a3d7f45027aefdc")
       .put("itemId", "item-1")
       .put("itemType", "ResourceGroup")
       .put("role", "consumer");


### PR DESCRIPTION
- bcrypt'd secret caused issues in client authentication
- changed secret to random hex string, and storing sha512 of secret in DB
- updated createUser service and clientAuthentication handler
- updated tests and Utils helper class
- updated OpenAPI spec