### PR TITLE
Bugfix - make RegistrationService.getUserDetails send JsonObject

### DIFF
--- a/src/main/java/iudx/aaa/server/registration/RegistrationService.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationService.java
@@ -107,5 +107,5 @@ public interface RegistrationService {
 
   @Fluent
   RegistrationService getUserDetails(List<String> userIds,
-      Handler<AsyncResult<Map<String, JsonObject>>> handler);
+      Handler<AsyncResult<JsonObject>> handler);
 }

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -555,11 +555,11 @@ public class RegistrationServiceImpl implements RegistrationService {
 
   @Override
   public RegistrationService getUserDetails(List<String> userIds,
-      Handler<AsyncResult<Map<String, JsonObject>>> handler) {
+      Handler<AsyncResult<JsonObject>> handler) {
     LOGGER.debug("Info : " + LOGGER.getName() + " : Request received");
 
     if (userIds.isEmpty()) {
-      handler.handle(Future.succeededFuture(new HashMap<String, JsonObject>()));
+      handler.handle(Future.succeededFuture(new JsonObject()));
       return this;
     }
 
@@ -601,9 +601,9 @@ public class RegistrationServiceImpl implements RegistrationService {
     /* 'merge' userId-KcId and KcId-details maps */
     details.onSuccess(kcToDetails -> {
       Map<String, String> user2kc = userToKc.future().result();
-      Map<String, JsonObject> userDetails = user2kc.entrySet().stream()
-          .collect(Collectors.toMap(id -> id.getKey(), id -> kcToDetails.get(id.getValue())));
+      JsonObject userDetails = new JsonObject();
 
+      user2kc.forEach((userId, kcId) -> userDetails.put(userId, kcToDetails.get(kcId)));
       handler.handle(Future.succeededFuture(userDetails));
     }).onFailure(e -> {
       if (e.getMessage().equals(COMPOSE_FAILURE)) {

--- a/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
@@ -180,7 +180,8 @@ public class ListDelegationTest {
     }).onSuccess(r -> {
 
       registrationService = mockRegistrationFactory.getInstance();
-      policyService = new PolicyServiceImpl(pool, registrationService, catalogueClient,authOptions,catOptions);
+      policyService = new PolicyServiceImpl(pool, registrationService, catalogueClient, authOptions,
+          catOptions);
       testContext.completeNow();
     });
   }
@@ -205,9 +206,9 @@ public class ListDelegationTest {
   /**
    * Creates valid userDetails response for the providerAdmin and delegate users.
    * 
-   * @return a map with the userDetails response
+   * @return a JsonObject with the userDetails response
    */
-  Map<String, JsonObject> createUserDetailsResponse() {
+  JsonObject createUserDetailsResponse() {
     JsonObject paUser = providerAdmin.result();
     JsonObject deleUser = delegate.result();
 
@@ -219,7 +220,8 @@ public class ListDelegationTest {
         new JsonObject().put("firstName", deleUser.getString("firstName")).put("lastName",
             deleUser.getString("lastName")));
 
-    return Map.of(paUser.getString("userId"), paDets, deleUser.getString("userId"), deleDets);
+    return new JsonObject().put(paUser.getString("userId"), paDets)
+        .put(deleUser.getString("userId"), deleDets);
   }
 
   @Test

--- a/src/test/java/iudx/aaa/server/policy/MockRegistrationFactory.java
+++ b/src/test/java/iudx/aaa/server/policy/MockRegistrationFactory.java
@@ -3,15 +3,10 @@ package iudx.aaa.server.policy;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import iudx.aaa.server.registration.RegistrationService;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-
-import java.util.HashMap;
-import java.util.Map;
-
 
 /**
  * Mocks, stubs the RegistrationService.
@@ -21,7 +16,7 @@ import java.util.Map;
 public class MockRegistrationFactory {
 
   private static RegistrationService registrationService;
-  AsyncResult<Map<String,JsonObject>> asyncResult;
+  AsyncResult<JsonObject> asyncResult;
 
   @SuppressWarnings("unchecked")
   public MockRegistrationFactory() {
@@ -30,8 +25,8 @@ public class MockRegistrationFactory {
     }
 
     asyncResult = Mockito.mock(AsyncResult.class);
-    Mockito.doAnswer((Answer<AsyncResult<Map<String,JsonObject>>>) arguments -> {
-      ((Handler<AsyncResult<Map<String,JsonObject>>>) arguments.getArgument(1)).handle(asyncResult);
+    Mockito.doAnswer((Answer<AsyncResult<JsonObject>>) arguments -> {
+      ((Handler<AsyncResult<JsonObject>>) arguments.getArgument(1)).handle(asyncResult);
       return null;
     }).when(registrationService).getUserDetails(Mockito.any(), Mockito.any());
   }
@@ -48,7 +43,7 @@ public class MockRegistrationFactory {
    */
 
   public void setResponse(String status) {
-    Map<String,JsonObject> response = new HashMap<>();
+    JsonObject response = new JsonObject();
     JsonObject obj = new JsonObject();
     if ("valid".equals(status)) {
       obj.put("name","abc").put("email","abc@xyz.com");
@@ -70,7 +65,7 @@ public class MockRegistrationFactory {
    * 
    * @param response is void
    */
-  public void setResponse(Map<String, JsonObject> response) {
+  public void setResponse(JsonObject response) {
     Mockito.when(asyncResult.result()).thenReturn(response);
     Mockito.when(asyncResult.failed()).thenReturn(false);
     Mockito.when(asyncResult.succeeded()).thenReturn(true);


### PR DESCRIPTION
- Sending Map<String,JsonObject> caused class casting problems when separate verticles
were clustered and communicating on a distributed event bus, so changed to JsonObject
- Updated list APIs, listPolicy, listNotification and listDelegation to handle JsonObject
- Updated MockRegistrationFactory
- Updated tests as well as ListDelegation and ListPolicy tests