### PR TITLE
Bug fix - handle connection errors for postgres + fix client auth response

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
@@ -72,7 +72,7 @@ public class ClientAuthentication implements AuthenticationHandler{
           if (dbHandler.failed()) {
             LOGGER.error(LOG_DB_ERROR + dbHandler.cause());
             Response rs = new ResponseBuilder().title(INTERNAL_SVR_ERR).status(500)
-                .detail(dbHandler.cause().getLocalizedMessage()).build();
+                .detail(INTERNAL_SVR_ERR).build();
             routingContext.fail(new Throwable(rs.toJsonString()));
             return;
           } else if (dbHandler.succeeded()) {
@@ -142,7 +142,7 @@ public class ClientAuthentication implements AuthenticationHandler{
 
     Promise<JsonObject> promise = Promise.promise();
     pgPool.withConnection(connection -> connection.preparedQuery(query).execute(Tuple.of(id))
-        .map(rows -> rows.rowCount() > 0 ? rows.iterator().next().toJson() : new JsonObject())
+        .map(rows -> rows.rowCount() > 0 ? rows.iterator().next().toJson() : new JsonObject()))
         .onComplete(handler -> {
           if (handler.succeeded()) {
             JsonObject details = handler.result();
@@ -150,7 +150,7 @@ public class ClientAuthentication implements AuthenticationHandler{
           } else if (handler.failed()) {
             promise.fail(handler.cause());
           }
-        }));
+        });
     return promise.future();
   }
   

--- a/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
@@ -77,10 +77,10 @@ public class ClientAuthentication implements AuthenticationHandler{
             return;
           } else if (dbHandler.succeeded()) {
             if (dbHandler.result().isEmpty()) {
-              Response rs = new ResponseBuilder().status(401).type(URN_MISSING_AUTH_TOKEN)
-                  .title(TOKEN_FAILED).detail(TOKEN_FAILED).build();
+              Response rs = new ResponseBuilder().status(401).type(URN_INVALID_INPUT)
+                  .title(INVALID_CLIENT_ID_SEC).detail(INVALID_CLIENT_ID_SEC).build();
               routingContext.fail(new Throwable(rs.toJsonString()));
-              routingContext.end();
+              return;
             }
           }
 

--- a/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
@@ -66,7 +66,9 @@ public class OIDCAuthentication implements AuthenticationHandler {
 
     iudx.aaa.server.apiserver.User.UserBuilder user = new UserBuilder();
 
-    /* Handles OIDC Token Flow */
+    /* Handles OIDC Token Flow
+     * A combination of routingContext.fail and routingContext.end ends the compose
+     * chain and prevents all the onFailure blocks from being triggered */
     if (token != null && !token.isBlank()) {
       JsonObject credentials = new JsonObject().put("access_token", token);
       keycloak.authenticate(credentials).onFailure(authHandler -> {

--- a/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
@@ -116,7 +116,7 @@ public class OIDCAuthentication implements AuthenticationHandler {
         } else if (kcHandler.failed()) {
           LOGGER.error("Fail: Request validation and authentication; " + kcHandler.cause());
           Response rs = new ResponseBuilder().status(500).title(INTERNAL_SVR_ERR)
-              .detail(kcHandler.cause().getLocalizedMessage()).build();
+              .detail(INTERNAL_SVR_ERR).build();
           routingContext.fail(new Throwable(rs.toJsonString()));
         }
       });
@@ -171,7 +171,7 @@ public class OIDCAuthentication implements AuthenticationHandler {
 
     Promise<JsonObject> promise = Promise.promise();
     pgPool.withConnection(connection -> connection.preparedQuery(query).execute(Tuple.of(id))
-        .map(rows -> rows.rowCount() > 0 ? rows.iterator().next().toJson() : new JsonObject())
+        .map(rows -> rows.rowCount() > 0 ? rows.iterator().next().toJson() : new JsonObject()))
         .onComplete(handler -> {
           if (handler.succeeded()) {
             JsonObject details = handler.result();
@@ -179,7 +179,7 @@ public class OIDCAuthentication implements AuthenticationHandler {
           } else if (handler.failed()) {
             promise.fail(handler.cause());
           }
-        }));
+        });
     return promise.future();
   }
 

--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -350,7 +350,7 @@ public class TokenServiceImpl implements TokenService {
 
     Promise<JsonArray> promise = Promise.promise();
     pgPool.withConnection(
-        connection -> connection.preparedQuery(query).execute(tuple).onComplete(handler -> {
+        connection -> connection.preparedQuery(query).execute(tuple)).onComplete(handler -> {
           if (handler.succeeded()) {
             JsonArray jsonResult = new JsonArray();
             for (Row each : handler.result()) {
@@ -360,7 +360,7 @@ public class TokenServiceImpl implements TokenService {
           } else if (handler.failed()) {
             promise.fail(handler.cause());
           }
-        }));
+        });
     return promise.future();
   }
 }


### PR DESCRIPTION
- For queries in these methods, postgres connection errors were not
getting handled (e.g. invalid password/user or postgres version
incompatibility)
- We now check the success/failure status of pgPool.withConnection itself
- For OIDC and Client auth, send generic internal error instead of actual
error

- Change title, detail for not found client ID
- Remove routingContext.end - was causing 'response already sent error'