### PR TITLE
Added CLI command to deploy selected services/modules in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,51 @@ export LOG_LEVEL=INFO
    `mvn clean compile exec:java@aaa-server`
 4. The server will be up in Port 8443.
 
+### JAR based
+1. Install java 11 and maven
+2. Set Environment variables
+```
+export AUTH_URL=http://<auth-domain-name>
+export LOG_LEVEL=INFO
+```
+3. Use maven to package the application as a JAR
+   `mvn clean package -Dmaven.test.skip=true`
+4. 2 JAR files would be generated in the `target/` directory
+    - `iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar` - clustered vert.x containing micrometer metrics
+    - `iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar` - non-clustered vert.x and does not contain micrometer metrics
 
+#### Running the clustered JAR
+The JAR requires 3 runtime arguments when running:
+
+* --config/-c : path to the config file</li>
+* --hostname/-i : the hostname for clustering</li>
+* --modules/-m : comma separated list of module names to deploy</li>
+
+ e.g. `java -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar --host $(hostname) -c configs/config.json -m iudx.aaa.server.admin.AdminVerticle,iudx.aaa.server.token.TokenVerticle ,iudx.aaa.server.registration.RegistrationVerticle,iudx.aaa.server.auditing.AuditingVerticle`
+
+Use the `--help/-h` argument for more information. You may additionally append an `AUTH_JAVA_OPTS` environment variable containing any Java options to pass to the application.
+
+e.g.
+```
+$ export AUTH_JAVA_OPTS="-Xms128m -Xmx512m"
+$ java AUTH_JAVA_OPTS -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar ...
+```
+
+#### Running the non-clustered JAR
+The JAR requires 1 runtime argument when running:
+
+* --config/-c : path to the config file</li>
+
+e.g. `java -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar -c configs/config.json`
+
+Use the `--help/-h` argument for more information. You may additionally append an `AUTH_JAVA_OPTS` environment variable containing any Java options to pass to the application.
+
+e.g.
+```
+$ export AUTH_JAVA_OPTS="-Xms128m -Xmx512m"
+$ java AUTH_JAVA_OPTS -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar ...
+```
+    
 ### Testing
 
 ### TDD based Unit test flow

--- a/README.md
+++ b/README.md
@@ -108,20 +108,23 @@ export LOG_LEVEL=INFO
     - `iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar` - non-clustered vert.x and does not contain micrometer metrics
 
 #### Running the clustered JAR
+
+**Note**: The clustered JAR requires Zookeeper to be installed. Refer [here](https://zookeeper.apache.org/doc/r3.3.3/zookeeperStarted.html) to learn more about how to set up Zookeeper. Additionally, the `zookeepers` key in the config being used needs to be updated with the IP address/domain of the system running Zookeeper.
+
 The JAR requires 3 runtime arguments when running:
 
 * --config/-c : path to the config file</li>
 * --hostname/-i : the hostname for clustering</li>
 * --modules/-m : comma separated list of module names to deploy</li>
 
- e.g. `java -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar --host $(hostname) -c configs/config.json -m iudx.aaa.server.admin.AdminVerticle,iudx.aaa.server.token.TokenVerticle ,iudx.aaa.server.registration.RegistrationVerticle,iudx.aaa.server.auditing.AuditingVerticle`
+ e.g. `java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar --host $(hostname) -c configs/config.json -m iudx.aaa.server.admin.AdminVerticle,iudx.aaa.server.token.TokenVerticle ,iudx.aaa.server.registration.RegistrationVerticle,iudx.aaa.server.auditing.AuditingVerticle`
 
 Use the `--help/-h` argument for more information. You may additionally append an `AUTH_JAVA_OPTS` environment variable containing any Java options to pass to the application.
 
 e.g.
 ```
 $ export AUTH_JAVA_OPTS="-Xms128m -Xmx512m"
-$ java AUTH_JAVA_OPTS -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar ...
+$ java $AUTH_JAVA_OPTS -jar target/iudx.aaa.server-cluster-0.0.1-SNAPSHOT-fat.jar ...
 ```
 
 #### Running the non-clustered JAR
@@ -129,14 +132,14 @@ The JAR requires 1 runtime argument when running:
 
 * --config/-c : path to the config file</li>
 
-e.g. `java -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar -c configs/config.json`
+e.g. `java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar -c configs/config.json`
 
 Use the `--help/-h` argument for more information. You may additionally append an `AUTH_JAVA_OPTS` environment variable containing any Java options to pass to the application.
 
 e.g.
 ```
 $ export AUTH_JAVA_OPTS="-Xms128m -Xmx512m"
-$ java AUTH_JAVA_OPTS -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar ...
+$ java $AUTH_JAVA_OPTS -jar target/iudx.aaa.server-dev-0.0.1-SNAPSHOT-fat.jar ...
 ```
     
 ### Testing

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "auth.iudx.io",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -201,6 +201,13 @@ public class Deployer {
 
   }
 
+  /**
+   * Graceful shutdown of Vertx application in a sequential manner - 1) undeploy verticle including
+   * unregistering of services through the stop method of verticle 2) unregister the vertx from
+   * cluster 3) shutdown of vertx 4) shutdown of log4g2. The function is triggered by shutdown hook
+   * on a normal shutdown of application.
+   */
+
   public static void gracefulShutdown() {
     Set<String> deployIDSet = vertx.deploymentIDs();
     Logger LOGGER = LogManager.getLogger(Deployer.class);

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -63,7 +63,6 @@ public class Deployer {
       return;
     }
     JsonObject config = configs.getJsonArray("modules").getJsonObject(i);
-    config.put("host", configs.getString("host"));
     String moduleName = config.getString("id");
     int numInstances = config.getInteger("verticleInstances");
     vertx.deployVerticle(moduleName,
@@ -101,7 +100,6 @@ public class Deployer {
       return;
     }
 
-    config.put("host", configs.getString("host"));
     int numInstances = config.getInteger("verticleInstances");
     vertx.deployVerticle(moduleName,
         new DeploymentOptions().setInstances(numInstances).setConfig(config), ar -> {

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -1,48 +1,46 @@
 package iudx.aaa.server.deploy;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import java.util.EnumSet;
-
-import io.vertx.core.eventbus.EventBusOptions;
-import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
-import iudx.aaa.server.apiserver.Schema;
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.zookeeper.*;
-
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.cli.CLI;
-import io.vertx.core.cli.Option;
-import io.vertx.core.cli.CommandLine;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Promise;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
-import java.nio.file.Files;
-
-import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.Label;
+import com.hazelcast.zookeeper.ZookeeperDiscoveryProperties;
+import com.hazelcast.zookeeper.ZookeeperDiscoveryStrategyFactory;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.vertx.micrometer.backends.BackendRegistries;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 // JVM metrics imports
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.cli.CLI;
+import io.vertx.core.cli.CommandLine;
+import io.vertx.core.cli.Option;
+import io.vertx.core.cli.TypedOption;
+import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+import iudx.aaa.server.apiserver.Schema;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -52,6 +50,13 @@ public class Deployer {
   private static ClusterManager mgr;
   private static Vertx vertx;
 
+  /**
+   * Recursively deploy all modules.
+   * 
+   * @param vertx the vert.x instance
+   * @param configs the JSON configuration
+   * @param i for recursive base case
+   */
   public static void recursiveDeploy(Vertx vertx, JsonObject configs, int i) {
     if (i >= configs.getJsonArray("modules").size()) {
       LOGGER.info("Deployed all");
@@ -62,22 +67,56 @@ public class Deployer {
     String moduleName = config.getString("id");
     int numInstances = config.getInteger("verticleInstances");
     vertx.deployVerticle(moduleName,
-                           new DeploymentOptions()
-                                  .setInstances(numInstances)
-                                  .setConfig(config),
-                          ar -> {
-      if (ar.succeeded()) {
-        LOGGER.info("Deployed " + moduleName);
-        recursiveDeploy(vertx, configs, i+1);
-      } else {
-        LOGGER.fatal("Failed to deploy " + moduleName + " cause:", ar.cause());
-      }
-    });
+        new DeploymentOptions().setInstances(numInstances).setConfig(config), ar -> {
+          if (ar.succeeded()) {
+            LOGGER.info("Deployed " + moduleName);
+            recursiveDeploy(vertx, configs, i + 1);
+          } else {
+            LOGGER.fatal("Failed to deploy " + moduleName + " cause:", ar.cause());
+          }
+        });
   }
 
-  public static ClusterManager getClusterManager(String host,
-                                                  List<String> zookeepers,
-                                                  String clusterID) {
+  /**
+   * Recursively deploy modules/verticles (if they exist) present in the `modules` list.
+   * 
+   * @param vertx the vert.x instance
+   * @param configs the JSON configuration
+   * @param modules the list of modules to deploy
+   */
+  public static void recursiveDeploy(Vertx vertx, JsonObject configs, List<String> modules) {
+    if (modules.isEmpty()) {
+      LOGGER.info("Deployed requested verticles");
+      return;
+    }
+
+    JsonArray configuredModules = configs.getJsonArray("modules");
+
+    String moduleName = modules.get(0);
+    JsonObject config = configuredModules.stream().map(obj -> (JsonObject) obj)
+        .filter(obj -> obj.getString("id").equals(moduleName)).findFirst().orElse(new JsonObject());
+
+    if (config.isEmpty()) {
+      LOGGER.fatal("Failed to deploy " + moduleName + " cause: Not Found");
+      return;
+    }
+
+    config.put("host", configs.getString("host"));
+    int numInstances = config.getInteger("verticleInstances");
+    vertx.deployVerticle(moduleName,
+        new DeploymentOptions().setInstances(numInstances).setConfig(config), ar -> {
+          if (ar.succeeded()) {
+            LOGGER.info("Deployed " + moduleName);
+            modules.remove(0);
+            recursiveDeploy(vertx, configs, modules);
+          } else {
+            LOGGER.fatal("Failed to deploy " + moduleName + " cause:", ar.cause());
+          }
+        });
+  }
+
+  public static ClusterManager getClusterManager(String host, List<String> zookeepers,
+      String clusterID) {
     Config config = new Config();
     config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
     config.getNetworkConfig().setPublicAddress(host);
@@ -86,12 +125,10 @@ public class Deployer {
     DiscoveryStrategyConfig discoveryStrategyConfig =
         new DiscoveryStrategyConfig(new ZookeeperDiscoveryStrategyFactory());
     discoveryStrategyConfig.addProperty(ZookeeperDiscoveryProperties.ZOOKEEPER_URL.key(),
-                                          String.join(",", zookeepers));
+        String.join(",", zookeepers));
     discoveryStrategyConfig.addProperty(ZookeeperDiscoveryProperties.GROUP.key(), clusterID);
-    config.getNetworkConfig()
-          .getJoin()
-          .getDiscoveryConfig()
-          .addDiscoveryStrategyConfig(discoveryStrategyConfig);
+    config.getNetworkConfig().getJoin().getDiscoveryConfig()
+        .addDiscoveryStrategyConfig(discoveryStrategyConfig);
 
     return new HazelcastClusterManager(config);
   }
@@ -102,8 +139,8 @@ public class Deployer {
             new VertxPrometheusOptions().setEnabled(true).setStartEmbeddedServer(true)
                 .setEmbeddedServerOptions(new HttpServerOptions().setPort(9000)))
         // .setPublishQuantiles(true))
-        .setLabels(EnumSet.of(Label.EB_ADDRESS, Label.EB_FAILURE, Label.HTTP_CODE,
-            Label.HTTP_METHOD))
+        .setLabels(
+            EnumSet.of(Label.EB_ADDRESS, Label.EB_FAILURE, Label.HTTP_CODE, Label.HTTP_METHOD))
         .setEnabled(true);
   }
 
@@ -118,10 +155,17 @@ public class Deployer {
 
   }
 
-  public static void deploy(String configPath, String host) {
+  /**
+   * Deploy clustered vert.x instance.
+   * 
+   * @param configPath the path for JSON config file
+   * @param host
+   * @param modules list of modules to deploy. If list is empty, all modules are deployed
+   */
+  public static void deploy(String configPath, String host, List<String> modules) {
     String config;
     try {
-     config = new String(Files.readAllBytes(Paths.get(configPath)), StandardCharsets.UTF_8);
+      config = new String(Files.readAllBytes(Paths.get(configPath)), StandardCharsets.UTF_8);
     } catch (Exception e) {
       LOGGER.fatal("Couldn't read configuration file");
       return;
@@ -147,7 +191,11 @@ public class Deployer {
         vertx = res.result();
         LOGGER.debug(vertx.isMetricsEnabled());
         setJVMmetrics();
-        recursiveDeploy(vertx, configuration, 0);
+        if (modules.isEmpty()) {
+          recursiveDeploy(vertx, configuration, 0);
+        } else {
+          recursiveDeploy(vertx, configuration, modules);
+        }
       } else {
         LOGGER.fatal("Could not join cluster");
       }
@@ -156,73 +204,77 @@ public class Deployer {
   }
 
   public static void gracefulShutdown() {
-	    Set<String> deployIDSet = vertx.deploymentIDs();
-	    Logger LOGGER = LogManager.getLogger(Deployer.class);
-	    LOGGER.info("Shutting down the application");
-	    CountDownLatch latch_verticles = new CountDownLatch(deployIDSet.size());
-	    CountDownLatch latch_cluster = new CountDownLatch(1);
-	    CountDownLatch latch_vertx = new CountDownLatch(1);
-	    LOGGER.debug("number of verticles being undeployed are:" + deployIDSet.size());
-	    // shutdown verticles
-	    for (String deploymentID : deployIDSet) {
-	      vertx.undeploy(deploymentID, handler -> {
-	        if (handler.succeeded()) {
-	          LOGGER.debug(deploymentID + " verticle  successfully Undeployed");
-	          latch_verticles.countDown();
-	        } else {
-	          LOGGER.warn(deploymentID + "Undeploy failed!");
-	        }
+    Set<String> deployIDSet = vertx.deploymentIDs();
+    Logger LOGGER = LogManager.getLogger(Deployer.class);
+    LOGGER.info("Shutting down the application");
+    CountDownLatch latch_verticles = new CountDownLatch(deployIDSet.size());
+    CountDownLatch latch_cluster = new CountDownLatch(1);
+    CountDownLatch latch_vertx = new CountDownLatch(1);
+    LOGGER.debug("number of verticles being undeployed are:" + deployIDSet.size());
+    // shutdown verticles
+    for (String deploymentID : deployIDSet) {
+      vertx.undeploy(deploymentID, handler -> {
+        if (handler.succeeded()) {
+          LOGGER.debug(deploymentID + " verticle  successfully Undeployed");
+          latch_verticles.countDown();
+        } else {
+          LOGGER.warn(deploymentID + "Undeploy failed!");
+        }
 
-	      });
-	    }
+      });
+    }
 
-	    try {
-	      latch_verticles.await(5, TimeUnit.SECONDS);
-	      LOGGER.info("All the verticles undeployed");
-	      Promise<Void> promise = Promise.promise();
-	      // leave the cluster
-	      mgr.leave(promise);
-	      LOGGER.info("vertx left cluster succesfully");
-	    } catch (Exception e) {
-	      e.printStackTrace();
-	    }
+    try {
+      latch_verticles.await(5, TimeUnit.SECONDS);
+      LOGGER.info("All the verticles undeployed");
+      Promise<Void> promise = Promise.promise();
+      // leave the cluster
+      mgr.leave(promise);
+      LOGGER.info("vertx left cluster succesfully");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
 
-	    try {
-	      latch_cluster.await(5, TimeUnit.SECONDS);
-	      // shutdown vertx
-	      vertx.close(handler -> {
-	        if (handler.succeeded()) {
-	          LOGGER.info("vertx closed succesfully");
-	          latch_vertx.countDown();
-	        } else {
-	          LOGGER.warn("Vertx didn't close properly, reason:" + handler.cause());
-	        }
-	      });
-	    } catch (Exception e) {
-	      e.printStackTrace();
-	    }
+    try {
+      latch_cluster.await(5, TimeUnit.SECONDS);
+      // shutdown vertx
+      vertx.close(handler -> {
+        if (handler.succeeded()) {
+          LOGGER.info("vertx closed succesfully");
+          latch_vertx.countDown();
+        } else {
+          LOGGER.warn("Vertx didn't close properly, reason:" + handler.cause());
+        }
+      });
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
 
-	    try {
-	      latch_vertx.await(5, TimeUnit.SECONDS);
-	      // then shut down log4j
-	      if( LogManager.getContext() instanceof LoggerContext ) {
-	        LOGGER.debug("Shutting down log4j2");
-	        LogManager.shutdown((LoggerContext) LogManager.getContext());
-	      } else
-	        LOGGER.warn("Unable to shutdown log4j2");
-	    } catch (Exception e) {
-	      e.printStackTrace();
-	    }
-	  }
+    try {
+      latch_vertx.await(5, TimeUnit.SECONDS);
+      // then shut down log4j
+      if (LogManager.getContext() instanceof LoggerContext) {
+        LOGGER.debug("Shutting down log4j2");
+        LogManager.shutdown((LoggerContext) LogManager.getContext());
+      } else
+        LOGGER.warn("Unable to shutdown log4j2");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
 
   public static void main(String[] args) {
     CLI cli = CLI.create("IUDX Auth").setSummary("A CLI to deploy the resource")
         .addOption(new Option().setLongName("help").setShortName("h").setFlag(true)
             .setDescription("display help"))
-        .addOption(new Option().setLongName("config").setShortName("c")
-            .setRequired(true).setDescription("configuration file"))
+        .addOption(new Option().setLongName("config").setShortName("c").setRequired(true)
+            .setDescription("configuration file"))
         .addOption(new Option().setLongName("host").setShortName("i").setRequired(true)
-                .setDescription("public host"));;
+            .setDescription("public host"))
+        .addOption(new TypedOption<String>().setType(String.class).setLongName("modules")
+            .setShortName("m").setRequired(false).setDefaultValue("all").setParsedAsList(true)
+            .setDescription("comma separated list of verticle names to deploy. "
+                + "If omitted, or if `all` is passed, all verticles are deployed"));
 
     StringBuilder usageString = new StringBuilder();
     cli.usage(usageString);
@@ -230,10 +282,18 @@ public class Deployer {
     if (commandLine.isValid() && !commandLine.isFlagEnabled("help")) {
       String configPath = commandLine.getOptionValue("config");
       String host = commandLine.getOptionValue("host");
-      deploy(configPath,host);
+      List<String> passedModules = commandLine.getOptionValues("modules");
+      List<String> modules = passedModules.stream().distinct().collect(Collectors.toList());
+      
+      /* `all` is also passed by default if no -m option given.*/
+      if (modules.contains("all")) { 
+        deploy(configPath, host, List.of());
+      } else {
+        deploy(configPath, host, modules);
+      }
       Runtime.getRuntime().addShutdownHook(new Thread(() -> gracefulShutdown()));
     } else {
-      LOGGER.info(usageString);
+      System.out.println(usageString);
     }
   }
 

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -45,6 +45,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 
+/**
+ * Deploys clustered vert.x instance of the server. As a JAR, the application
+ * requires 3 runtime arguments:
+ * <ul>
+ * <li>--config/-c : path to the config file</li>
+ * <li>--hostname/-i : the hostname for clustering</li>
+ * <li>--modules/-m : comma separated list of module names to deploy</li>
+ * </ul>
+ * 
+ * e.g. <i>java -jar ./fatjar.jar  --host $(hostname) -c configs/config.json -m iudx.aaa.server.admin.AdminVerticle,iudx.aaa.server.token.TokenVerticle
+ * ,iudx.aaa.server.registration.RegistrationVerticle,iudx.aaa.server.auditing.AuditingVerticle</i> 
+ */
+
 public class Deployer {
   private static final Logger LOGGER = LogManager.getLogger(Deployer.class);
   private static ClusterManager mgr;

--- a/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
+++ b/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
@@ -23,8 +23,14 @@ import org.apache.logging.log4j.Logger;
 
 
 /**
- * DeploySingle - Deploy a single non-clustered resource server instance
- **/
+ * Deploys non-clustered vert.x instance of the server. As a JAR, the application
+ * requires 1 runtime argument:
+ * <ul>
+ * <li>--config/-c : path to the config file</li>
+ * </ul>
+ * 
+ * e.g. <i>java -jar ./fatjar.jar -c configs/config.json</i>
+ */
 public class DeployerDev {
   private static final Logger LOGGER = LogManager.getLogger(DeployerDev.class);
 
@@ -74,7 +80,7 @@ public class DeployerDev {
   }
 
   public static void main(String[] args) {
-    CLI cli = CLI.create("IUDX Cat").setSummary("A CLI to deploy the resource server")
+    CLI cli = CLI.create("IUDX Auth").setSummary("A CLI to deploy the resource")
         .addOption(new Option().setLongName("help").setShortName("h").setFlag(true)
             .setDescription("display help"))
         .addOption(new Option().setLongName("config").setShortName("c")


### PR DESCRIPTION
- In production, each service may be in different containers. To avoid
editing config to choose what to deploy, added the `--modules/-m` command
to the CLI
- comma separated module names passed as values or the `all` keyword
- If `all` is passed, or -m is not passed, all modules deployed
- Updated `deploy` method to take list of module names
- Overloaded `recursiveDeploy` to take list of module names
- Organised imports, formatting and added javadoc