### PR TITLE
Added, updated tests for create, introspect token

### DIFF
--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -262,7 +262,9 @@ public class TokenServiceImpl implements TokenService {
           handler.handle(Future.failedFuture(INTERNAL_SVR_ERR));
         } else if (dbHandler.succeeded()) {
 
-          if (dbHandler.result().size() != 1) {
+        JsonObject dbExistsRow = dbHandler.result().getJsonObject(0);
+        boolean flag = dbExistsRow.getBoolean(EXISTS);
+        if (flag == Boolean.FALSE) {
             LOGGER.error(LOG_TOKEN_AUTH + INVALID_SUB);
             Response resp = new ResponseBuilder().status(400).type(URN_INVALID_AUTH_TOKEN)
                 .title(TOKEN_FAILED).detail(INVALID_SUB).build();
@@ -311,7 +313,7 @@ public class TokenServiceImpl implements TokenService {
    * @param request
    * @return jwtToken
    */
-  private JsonObject getJwt(JsonObject request) {
+  public JsonObject getJwt(JsonObject request) {
     
     JWTOptions options = new JWTOptions().setAlgorithm(JWT_ALGORITHM);
     long timestamp = System.currentTimeMillis() / 1000;

--- a/src/test/java/iudx/aaa/server/token/MockPolicyFactory.java
+++ b/src/test/java/iudx/aaa/server/token/MockPolicyFactory.java
@@ -4,6 +4,7 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.policy.PolicyServiceImpl;
@@ -51,6 +52,26 @@ public class MockPolicyFactory {
       Mockito.when(asyncResult.cause()).thenReturn(new Throwable(response.toString()));
       Mockito.when(asyncResult.succeeded()).thenReturn(false);
       Mockito.when(asyncResult.failed()).thenReturn(true);
+    }
+  }
+
+  /**
+   * Mock success response of verifyPolicy
+   * 
+   * @param status if it is a valid/invalid call
+   * @param item the cat ID of the item
+   * @param url the url of the server
+   */
+  public void setResponse(String status, String item, String url) {
+    if ("valid".equals(status)) {
+    JsonObject response = new JsonObject();
+      response.put("status", "success");
+      response.put("cat_id", item);
+      response.put("url", url);
+      response.put("constraints", new JsonObject().put("access", new JsonArray().add("api")));
+      Mockito.when(asyncResult.result()).thenReturn(response);
+      Mockito.when(asyncResult.failed()).thenReturn(false);
+      Mockito.when(asyncResult.succeeded()).thenReturn(true);
     }
   }
 }

--- a/src/test/java/iudx/aaa/server/token/RequestPayload.java
+++ b/src/test/java/iudx/aaa/server/token/RequestPayload.java
@@ -17,21 +17,6 @@ import iudx.aaa.server.apiserver.User.UserBuilder;
  */
 public class RequestPayload {
   
-  /* Payload for createToken */
-  public static JsonArray roleList = new JsonArray("[\"delegate\",\"provider\"]");
-  
-  public static JsonObject validPayload = new JsonObject().put("clientId", "349b4b55-0251-490e-bee9-00f3a5d3e643")
-      .put("clientSecret","e980d5bda287fa4808f8b6d32a3d7f45027aefdc")
-      .put("itemId", "item-1")
-      .put("itemType", "ResourceGroup")
-      .put("role", "consumer");
-  
-  public static JsonObject invalidClientId = validPayload.copy().put("clientId", "0343dab6-aa61-4024-a6ff-3b52e8d488f1");
-  
-  public static JsonObject invalidClientSecret = validPayload.copy().put("clientSecret", "0343dab6-aa61-4024-a6ff-3b52e8d488f1");
-  
-  public static JsonObject undefinedRole = validPayload.copy().put("role", "dev");
-  
   /* Payload for tokenRevoke */
   public static JsonObject revokeTokenValidPayload = new JsonObject().put("clientId", "349b4b55-0251-490e-bee9-00f3a5d3e643")
       .put("rsUrl", "foobar.iudx.io");
@@ -40,13 +25,6 @@ public class RequestPayload {
   public static JsonObject revokeTokenInvalidUrl = revokeTokenValidPayload.copy().put("rsUrl", "barfoo.iudx.io");
   
   /* Payload for TIP */
-  public static JsonObject validTipPayload = new JsonObject().put("accessToken", "eyJ0eXAiOiJKV1QiLC"
-      + "JhbGciOiJFUzI1NiJ9.eyJzdWIiOiIzNDliNGI1NS0wMjUxLTQ5MGUtYmVlOS0wMGYzYTVkM2U2NDMiLCJpc3MiOiJh"
-      + "dXRoLnRlc3QuY29tIiwiYXVkIjoidGVzdC5jYXQuY29tIiwiZXhwIjoxNjg4NjA5MzMyLCJpYXQiOjE2MjU0OTQxMzI"
-      + "sImlpZCI6InJpOmRhdGFrYXZlcmkub3JnL2Y3ZTA0NGVlZTgxMjJiNWM4N2RjZTZlN2FkNjRmMzI2NmFmYTQxZGMvcn"
-      + "MuaXVkeC5pby9hcW0tYm9zY2gtY2xpbW8vRldSMDE3Iiwicm9sZSI6InByb3ZpZGVyIiwiY29ucyI6e319.CHivWv6v"
-      + "Oz8FH5jiTfaTq8rQnyG1Pd4pusEj6PBWp4ouRlKHQcsuo50ZLMHvPBv2YQADOXS_XlZfg4OsDAsffg");
-  
   public static JsonObject expiredTipPayload = new JsonObject().put("accessToken", "eyJ0eXAiOiJKV1QiL"
       + "CJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIzNDliNGI1NS0wMjUxLTQ5MGUtYmVlOS0wMGYzYTVkM2U2NDMiLCJpc3MiO"
       + "iJhdXRoLnRlc3QuY29tIiwiYXVkIjoidGVzdC5jYXQuY29tIiwiZXhwIjoxNjIzOTA1MTY2LCJuYmYiOjE2MjM5MD"
@@ -55,36 +33,14 @@ public class RequestPayload {
       + "b25zdHJhaW50cyI6e319.YsRL87QZ68m-A1ALhAA2IdhM6BgxMjfeQxCRhf9Q2pajtFtuJGYCbcCd71xswXIRM4L7"
       + "WS05vznevd5JdxKkvQ");
   
-  public static JsonObject invalidTipPayload = new JsonObject().put("accessToken", validTipPayload.getString("accessToken")+"abc");
-  
+  public static JsonObject randomToken = new JsonObject().put("accessToken",
+      "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJFUzI1NmluT1RBIiwibmFtZSI6IkpvaG4gRG9lIn0.MEQCICRp"
+      + "hRrc0GWowZgJAy0gL6At628Kw8YPE22iD-aKIi4PAiA0JWU-qFNL8I0tP0ws3Bbmg0FfVMn4_yk2lGGquAGOXA");
   
   public static User user(String str) {
     UUID userId = UUID.fromString(str);
     User.UserBuilder userBuilder = new UserBuilder().userId(userId);
     return new User(userBuilder);
-  }
-  
-  public static User clientFlowUser() {
-    UUID kid = UUID.fromString("7539b9a4-9484-4efb-9a61-4c6a971df04d");
-    UUID userId = UUID.fromString("32a4b979-4f4a-4c44-b0c3-2fe109952b5f");
-    List<Roles> roles = RequestPayload.processRoles(new JsonArray().add("CONSUMER"));
-    
-    User.UserBuilder userBuilder = new UserBuilder().userId(userId).keycloakId(kid).roles(roles);
-    return new User(userBuilder);
-  }
-  
-  public static User oidcFlowUser() {
-    UUID kid = UUID.fromString("c46e7a5d-7c2d-471e-8222-6a59a5095e7a");
-    UUID userId = UUID.fromString("a13eb955-c691-4fd3-b200-f18bc78810b5");
-    List<Roles> roles = RequestPayload.processRoles(new JsonArray("[\"delegate\",\"provider\"]"));
-
-    User.UserBuilder userBuilder =
-        new UserBuilder().userId(userId).keycloakId(kid).roles(roles).name("good", "bye");
-    return new User(userBuilder);
-  }
-  
-  public static RequestToken mapToReqToken(JsonObject request) {
-    return request.copy().mapTo(RequestToken.class);
   }
   
   public static RevokeToken mapToRevToken(JsonObject request) {

--- a/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
+++ b/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
@@ -1,17 +1,26 @@
 package iudx.aaa.server.token;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.vertx.junit5.VertxExtension;
@@ -19,10 +28,17 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import iudx.aaa.server.apiserver.IntrospectToken;
+import iudx.aaa.server.apiserver.RequestToken;
+import iudx.aaa.server.apiserver.RoleStatus;
+import iudx.aaa.server.apiserver.Roles;
+import iudx.aaa.server.registration.Utils;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.MockRegistrationFactory;
 import iudx.aaa.server.policy.PolicyService;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static iudx.aaa.server.token.RequestPayload.*;
@@ -54,6 +70,26 @@ public class TokenServiceTest {
   private static TokenRevokeService httpWebClient;
   private static MockHttpWebClient mockHttpWebClient;
 
+  private static final String DUMMY_AUTH_SERVER =
+      "auth" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + "iudx.io";
+
+  private static final String DUMMY_SERVER =
+      "dummy" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
+
+  static String RESOURCE_GROUP =
+      "iisc.ac.in/da39a3ee5e6b4b0d3255bfef95601890afd80709/" + DUMMY_SERVER + "/resourcegroup";
+  static String RESOURCE_ITEM = RESOURCE_GROUP + "/resource";
+
+  public static final String NIL_UUID = "00000000-0000-0000-0000-000000000000";
+  static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+  static String url = name + ".com";
+  static Promise<UUID> orgId;
+
+  static Future<JsonObject> delegate;
+  static Future<JsonObject> providerAdmin;
+  static Future<JsonObject> consumer;
+
+  static Future<UUID> orgIdFut;
 
   @BeforeAll
   @DisplayName("Deploying Verticle")
@@ -101,14 +137,60 @@ public class TokenServiceTest {
     pgPool = PgPool.pool(vertx, connectOptions, poolOptions);
     // httpWebClient = new HttpWebClient(vertx, keycloakOptions);
 
-    mockPolicy = new MockPolicyFactory();
-    mockHttpWebClient = new MockHttpWebClient();
-    httpWebClient = mockHttpWebClient.getMockHttpWebClient();
+    orgIdFut = pgPool.withConnection(conn -> conn.preparedQuery(Utils.SQL_CREATE_ORG)
+        .execute(Tuple.of(name, url)).map(row -> row.iterator().next().getUUID("id")));
 
-    policyService = mockPolicy.getInstance();
-    tokenService = new TokenServiceImpl(pgPool, policyService, provider, httpWebClient);
+    providerAdmin = orgIdFut.compose(id -> Utils.createFakeUser(pgPool, id.toString(), url,
+        Map.of(Roles.PROVIDER, RoleStatus.APPROVED, Roles.ADMIN, RoleStatus.APPROVED), true));
 
-    testContext.completeNow();
+    delegate = orgIdFut.compose(id -> Utils.createFakeUser(pgPool, id.toString(), url,
+        Map.of(Roles.DELEGATE, RoleStatus.APPROVED), true));
+
+    consumer = orgIdFut.compose(id -> Utils.createFakeUser(pgPool, NIL_UUID, "",
+        Map.of(Roles.CONSUMER, RoleStatus.APPROVED), true));
+
+    /*
+     * 1. create organization 2. create 3 users 3. create 1 resource server with providerAdmin as
+     * admin 4. create 3 delegations, one for provider -> delegate on authsrv, one for other server
+     * to delegate, and a deleted delegation 5. AS provider, must view 2 delegations 6. AS delegate
+     * must view 2 delegations 7. AS auth delegate, must view one delegation 8. A consumer must not
+     * be able to call the API at all
+     */
+
+    CompositeFuture.all(orgIdFut, providerAdmin, delegate, consumer).compose(res -> {
+
+      UUID apId = UUID.fromString(providerAdmin.result().getString("userId"));
+      UUID deleId = UUID.fromString(delegate.result().getString("userId"));
+
+      List<Tuple> servers = List.of(Tuple.of("Other Server", apId, DUMMY_SERVER));
+      Tuple getServId = Tuple.of(List.of(DUMMY_AUTH_SERVER, DUMMY_SERVER).toArray());
+
+      Collector<Row, ?, Map<String, UUID>> serverIds =
+          Collectors.toMap(row -> row.getString("url"), row -> row.getUUID("id"));
+
+      return pgPool.withConnection(
+          conn -> conn.preparedQuery(Utils.SQL_CREATE_ADMIN_SERVER).executeBatch(servers));
+      /*
+       * .compose(succ -> conn.preparedQuery(SQL_GET_SERVER_IDS)
+       * .collecting(serverIds).execute(getServId).map(r -> r.value())) .map(i -> {
+       * 
+       * return List.of(Tuple.of(apId, deleId, i.get(DUMMY_SERVER), status.ACTIVE.toString()),
+       * Tuple.of(apId, deleId, i.get(DUMMY_SERVER), status.DELETED.toString()), Tuple.of(apId,
+       * deleId, i.get(AUTH_SERVER_URL), status.ACTIVE.toString()));
+       */
+      // }).compose(j -> conn.preparedQuery(SQL_CREATE_DELEG).executeBatch(j)));
+
+    }).onSuccess(r -> {
+
+      mockPolicy = new MockPolicyFactory();
+      mockHttpWebClient = new MockHttpWebClient();
+      httpWebClient = mockHttpWebClient.getMockHttpWebClient();
+
+      policyService = mockPolicy.getInstance();
+      tokenService = new TokenServiceImpl(pgPool, policyService, provider, httpWebClient);
+
+      testContext.completeNow();
+    });
   }
 
   /* Initializing JwtProvider */
@@ -123,17 +205,157 @@ public class TokenServiceTest {
   @AfterAll
   public static void finish(VertxTestContext testContext) {
     LOGGER.info("Finishing....");
-    vertxObj.close(testContext.succeeding(response -> testContext.completeNow()));
+    Tuple servers = Tuple.of(List.of(DUMMY_SERVER, DUMMY_AUTH_SERVER).toArray());
+    List<JsonObject> users = List.of(providerAdmin.result(), delegate.result(), consumer.result());
+
+    pgPool
+        .withConnection(conn -> conn.preparedQuery(Utils.SQL_DELETE_SERVERS).execute(servers)
+            .compose(success -> Utils.deleteFakeUser(pgPool, users)).compose(succ -> conn
+                .preparedQuery(Utils.SQL_DELETE_ORG).execute(Tuple.of(orgIdFut.result()))))
+        .onComplete(x -> {
+          if (x.failed()) {
+            LOGGER.warn(x.cause().getMessage());
+          }
+          vertxObj.close(testContext.succeeding(response -> testContext.completeNow()));
+        });
   }
 
   @Test
-  @DisplayName("createToken [Success]")
-  void createTokenSuccess(VertxTestContext testContext) {
+  @DisplayName("create token as consumer (resource group) [Success]")
+  void createTokenRsGrpSuccess(VertxTestContext testContext) {
+
+    JsonObject userJson = consumer.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", RESOURCE_GROUP)
+        .put("itemType", "resource_group").put("role", "consumer");
+    RequestToken request = new RequestToken(jsonReq);
 
     mockPolicy.setResponse("valid");
-    tokenService.createToken(mapToReqToken(validPayload), clientFlowUser(),
+    tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_SUCCESS, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("create token as consumer (resource item) [Success]")
+  void createTokenResItemSuccess(VertxTestContext testContext) {
+
+    JsonObject userJson = consumer.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", RESOURCE_ITEM).put("itemType", "resource")
+        .put("role", "consumer");
+    RequestToken request = new RequestToken(jsonReq);
+
+    mockPolicy.setResponse("valid");
+    tokenService.createToken(request, user,
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("create token as consumer (resource server) [Success]")
+  void createTokenResServSuccess(VertxTestContext testContext) {
+
+    JsonObject userJson = consumer.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", DUMMY_SERVER).put("itemType", "resource_server")
+        .put("role", "consumer");
+    RequestToken request = new RequestToken(jsonReq);
+
+    mockPolicy.setResponse("valid");
+    tokenService.createToken(request, user,
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("create token as admin for resource server [Success]")
+  void createTokenAdminSuccess(VertxTestContext testContext) {
+
+    JsonObject userJson = providerAdmin.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.ADMIN, Roles.PROVIDER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", DUMMY_SERVER).put("itemType", "resource_server")
+        .put("role", "admin");
+    RequestToken request = new RequestToken(jsonReq);
+
+    mockPolicy.setResponse("valid");
+    tokenService.createToken(request, user,
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("create token as admin for not found resource server [Fail]")
+  void createTokenAdminResServFail(VertxTestContext testContext) {
+
+    JsonObject userJson = providerAdmin.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.ADMIN, Roles.PROVIDER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", "abc.123.com").put("itemType", "resource_server")
+        .put("role", "admin");
+    RequestToken request = new RequestToken(jsonReq);
+
+    mockPolicy.setResponse("valid");
+    tokenService.createToken(request, user,
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("create token as FAKE admin for resource server [Fail]")
+  void createTokenConsumerResServFail(VertxTestContext testContext) {
+
+    JsonObject userJson = consumer.result();
+    
+    /* We *artificially* add the admin role to the consumer user when creating the
+     * user object */
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.ADMIN)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", DUMMY_SERVER).put("itemType", "resource_server")
+        .put("role", "admin");
+    RequestToken request = new RequestToken(jsonReq);
+
+    mockPolicy.setResponse("valid");
+    tokenService.createToken(request, user,
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_INVALID_INPUT, response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -142,8 +364,19 @@ public class TokenServiceTest {
   @DisplayName("createToken [Failed-01 invalidPolicy]")
   void createTokenFailed01(VertxTestContext testContext) {
 
+    JsonObject userJson = consumer.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", RESOURCE_ITEM).put("itemType", "resource")
+        .put("role", "consumer");
+    RequestToken request = new RequestToken(jsonReq);
+
     mockPolicy.setResponse("invalid");
-    tokenService.createToken(mapToReqToken(validPayload),clientFlowUser(),
+    tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
@@ -151,9 +384,20 @@ public class TokenServiceTest {
   }
 
   @Test
-  @DisplayName("createToken [Failed-04 undefinedRole]")
-  void createTokenFailed04(VertxTestContext testContext) {
+  @DisplayName("createToken user does not have requested role [Fail]")
+  void createTokenUserNotHaveRequestedRole(VertxTestContext testContext) {
 
+    JsonObject userJson = consumer.result();
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject jsonReq = new JsonObject().put("itemId", RESOURCE_ITEM).put("itemType", "resource")
+        .put("role", "delegate");
+    
+    RequestToken request = new RequestToken(jsonReq);
     mockPolicy.setResponse("valid");
     tokenService.createToken(mapToReqToken(undefinedRole), clientFlowUser(),
         testContext.succeeding(response -> testContext.verify(() -> {
@@ -167,7 +411,8 @@ public class TokenServiceTest {
   void revokeTokenSuccess(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload), user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
+        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_SUCCESS, response.getString(TYPE));
           // assertTrue(response.containsKey("accessToken"));
@@ -180,7 +425,8 @@ public class TokenServiceTest {
   void revokeTokenFailed01(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("invalid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload), user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
+        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
@@ -195,7 +441,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("valid");
     User.UserBuilder userBuilder = new UserBuilder();
     User user = new User(userBuilder);
-    
+
     tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload), user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
@@ -209,7 +455,8 @@ public class TokenServiceTest {
   void revokeTokenFailed03(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload), user("32a4b979-4f4a-4c44-b0c3-2fe109952b53"),
+    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
+        user("32a4b979-4f4a-4c44-b0c3-2fe109952b53"),
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
@@ -221,25 +468,27 @@ public class TokenServiceTest {
   void revokeTokenFailed04(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidUrl), user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidUrl),
+        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("revokeToken [Failed-05 invalidClientId]")
   void revokeTokenFailed05(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidClientId), user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidClientId),
+        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("validateToken [Success]")
   void validateTokenSuccess(VertxTestContext testContext) {
@@ -251,7 +500,7 @@ public class TokenServiceTest {
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("validateToken [Failed-01 invalidPolicy]")
   void validateTokenFailed01(VertxTestContext testContext) {
@@ -263,7 +512,7 @@ public class TokenServiceTest {
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("validateToken [Failed-02 invalidToken]")
   void validateTokenFailed02(VertxTestContext testContext) {
@@ -275,7 +524,7 @@ public class TokenServiceTest {
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("validateToken [Failed-03 expiredToken]")
   void validateTokenFailed03(VertxTestContext testContext) {
@@ -287,17 +536,48 @@ public class TokenServiceTest {
           testContext.completeNow();
         })));
   }
-  
+
   @Test
   @DisplayName("validateToken [Failed-04 missingToken]")
   void validateTokenFailed04(VertxTestContext testContext) {
 
     mockPolicy.setResponse("valid");
     IntrospectToken introspect = new IntrospectToken();
-    
+
     tokenService.validateToken(introspect,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_MISSING_INFO, response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("validateToken [Failed-05 randomToken]")
+  void validateTokenFailed05(VertxTestContext testContext) {
+
+    tokenService.validateToken(mapToInspctToken(randomToken),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
+          assertTrue(
+              response.getJsonArray("results").getJsonObject(0).getString(STATUS).equals(DENY));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("validateToken [Failed-06 user does not exist - should never happen]")
+  void validateTokenFailed06(VertxTestContext testContext) {
+
+    JsonObject tokenRequest = new JsonObject().put(Constants.ITEM_TYPE, "resourceGroup")
+        .put(Constants.ITEM_ID, RESOURCE_GROUP).put(Constants.USER_ID, UUID.randomUUID().toString())
+        .put(Constants.ROLE, Roles.CONSUMER.toString().toLowerCase());
+    JsonObject token = tokenServiceImplObj.getJwt(tokenRequest);
+    token.remove("expiry");
+    token.remove("server");
+
+    tokenService.validateToken(mapToInspctToken(token),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
           testContext.completeNow();
         })));
   }


### PR DESCRIPTION
TokenServiceTest
---------------
- Updated tests for create, introspect to rely on newly-created data
- Added new test cases
- Added code during start() and finish() to create and destroy data

MockPolicyFactory
-----------------
- Added method to mock verifyPolicy response with proper response

RequestPayload
--------------
- Removed unnecessary requests that relied on data present in test DB

TokenServiceImpl
----------------
- Updated check for userId not found in DB during introspect token
- Changed the getJwt method to public, so that function can be called
outside and test tokens can be created for introspect tests