### PR TITLE
Change config to stop repeated options

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -12,22 +12,23 @@
         "databaseName": "abc",
         "databaseUserName": "qwqws",
         "databasePassword": "wwd"
+      },
+      "commonOptions":{
+        "authServerDomain":"auth.test.com"
       }
   },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "domain" : "iudx.io.test",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io.test",
-        "catServerPort": "443",
-        "authServerUrl": "auth.iudx.io.test"
+        "catServerPort": "443"
       },
       "authOptions": {
-        "authServerUrl": "auth.iudx.io.test",
         "policyExpiry" : "12",
         "adminPolicyExpiry" : "60"
       },
@@ -53,8 +54,7 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "authServerDomain": "auth.test.com",
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -69,10 +69,7 @@
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "options": {
-        "authServerDomain": "foobar.iudx.io"
-      },
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -93,11 +90,10 @@
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
       "ssl": false,
-      "authServerDomain": "auth.iudx.io.test",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -15,6 +15,20 @@
       },
       "commonOptions":{
         "authServerDomain":"auth.test.com"
+      },
+      "keycloakOptions":{
+        "keycloakHost": "identity.iudx.io.test",
+        "keycloakPort": 8443,
+        "keycloakRealm": "some-realm",
+        "keycloakSite": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth/realms/{{keycloakRealm}}",
+        "keycloakUrl": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth",
+        "keycloakTokenUri": "/auth/realms/{{keycloakRealm}}/protocol/openid-connect/token",
+        "keycloakAdminClientId": "some-admin-client-id",
+        "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
+        "keycloakAdminPoolSize": "10",
+        "keycloakAaaClientId": "auth.iudx.test",
+        "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
+        "keycloakJwtLeeway": 90
       }
   },
   "modules": [
@@ -43,39 +57,22 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
-      "keycloakOptions": {
-        "host": "identity.iudx.io.test",
-        "port": 8443,
-        "uri": "/auth/realms/demo/protocol/openid-connect/token",
-        "clientId": "auth.iudx.test",
-        "clientSecret": "6ba458a0-06c6-89a0-a824-d53fc6d025f4"
-      }
+      "keystorePassword": "secret"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
     {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
@@ -93,16 +90,10 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
-      "corsRegexString": "*",
-      "keycloakOptions": {
-        "site": "https://identity.iudx.io.test/auth/realms/demo",
-        "clientId": "keycloakClientId",
-        "clientSecret": "keycloakClientSecret",
-        "jwtLeeway": 90
-      }
+      "corsRegexString": "*"
     }
   ]
 }

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -29,6 +29,10 @@
         "keycloakAaaClientId": "auth.iudx.test",
         "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
         "keycloakJwtLeeway": 90
+      },
+      "jwtKeystoreOptions":{
+        "keystorePath": "configs/keystore.jks",
+        "keystorePassword": "secret"
       }
   },
   "modules": [
@@ -63,10 +67,8 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
-      "poolSize": "5",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
+      "poolSize": "5"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
@@ -87,10 +89,8 @@
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
       "ssl": false,
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*"

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -5,15 +5,20 @@
   ],
   "clusterId": "iudx-aaa-cluster",
   "databaseSchema":"test",
+  "options":{
+      "postgresOptions": {
+        "databaseIP": "x.y.z.a",
+        "databasePort": "5432",
+        "databaseName": "abc",
+        "databaseUserName": "qwqws",
+        "databasePassword": "wwd"
+      }
+  },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "databaseIP": "x.y.z.a",
-      "databasePort": "5432",
-      "databaseName": "abc",
-      "databaseUserName": "qwqws",
-      "databasePassword": "wwd",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "domain" : "iudx.io.test",
       "catalogueOptions": {
@@ -37,11 +42,7 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "databaseIP": "x.y.z.a",
-      "databasePort": "5432",
-      "databaseName": "abc",
-      "databaseUserName": "qwqws",
-      "databasePassword": "wwd",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -53,11 +54,7 @@
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
       "authServerDomain": "auth.test.com",
-      "databaseIP": "x.y.z.a",
-      "databasePort": "5432",
-      "databaseName": "abc",
-      "databaseUserName": "qwqws",
-      "databasePassword": "wwd",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -75,11 +72,7 @@
       "options": {
         "authServerDomain": "foobar.iudx.io"
       },
-      "databaseIP": "x.y.z.a",
-      "databasePort": "5432",
-      "databaseName": "abc",
-      "databaseUserName": "qwqws",
-      "databasePassword": "wwd",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -104,11 +97,7 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "databaseIP": "x.y.z.a",
-      "databasePort": "5432",
-      "databaseName": "abc",
-      "databaseUserName": "qwqws",
-      "databasePassword": "wwd",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -29,6 +29,10 @@
         "keycloakAaaClientId": "auth.iudx.org.in",
         "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
         "keycloakJwtLeeway": 90
+      },
+      "jwtKeystoreOptions":{
+        "keystorePath": "configs/keystore.jks",
+        "keystorePassword": "secret"
       }
   },
   "modules": [
@@ -63,10 +67,8 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
-      "poolSize": "5",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
+      "poolSize": "5"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
@@ -86,10 +88,8 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*"

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -12,22 +12,23 @@
         "databaseName": "iudx",
         "databaseUserName": "iudx_user",
         "databasePassword": "iudx@123"
+      },
+      "commonOptions":{
+        "authServerDomain":"auth.test.com"
       }
   },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443",
-        "authServerUrl": "authdev.iudx.io"
+        "catServerPort": "443"
       },
       "authOptions": {
-        "authServerUrl": "authdev.iudx.io",
         "policyExpiry" : "12",
         "adminPolicyExpiry" : "60"
       },
@@ -53,8 +54,7 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "authServerDomain": "auth.test.com",
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -69,10 +69,7 @@
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "options": {
-        "authServerDomain": "foobar.iudx.io"
-      },
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -92,11 +89,10 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "authServerDomain": "auth.test.com",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -5,15 +5,20 @@
   ],
   "clusterId": "iudx-aaa-cluster",
   "databaseSchema":"test",
+  "options":{
+      "postgresOptions": {
+        "databaseIP": "139.59.80.176",
+        "databasePort": "5432",
+        "databaseName": "iudx",
+        "databaseUserName": "iudx_user",
+        "databasePassword": "iudx@123"
+      }
+  },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "domain" : "iudx.io",
       "catalogueOptions": {
@@ -37,11 +42,7 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -53,11 +54,7 @@
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
       "authServerDomain": "auth.test.com",
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -75,11 +72,7 @@
       "options": {
         "authServerDomain": "foobar.iudx.io"
       },
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -87,7 +80,7 @@
       "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
       "keycloakAdminPoolSize": "10"
     },
-    {
+     {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
       "verticleInstances": 1,
       "auditingDatabaseIP": "",
@@ -103,11 +96,7 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -15,6 +15,20 @@
       },
       "commonOptions":{
         "authServerDomain":"auth.test.com"
+      },
+      "keycloakOptions":{
+        "keycloakHost": "identitydev.iudx.io",
+        "keycloakPort": 8443,
+        "keycloakRealm": "some-realm",
+        "keycloakSite": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth/realms/{{keycloakRealm}}",
+        "keycloakUrl": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth",
+        "keycloakTokenUri": "/auth/realms/{{keycloakRealm}}/protocol/openid-connect/token",
+        "keycloakAdminClientId": "some-admin-client-id",
+        "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
+        "keycloakAdminPoolSize": "10",
+        "keycloakAaaClientId": "auth.iudx.org.in",
+        "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
+        "keycloakJwtLeeway": 90
       }
   },
   "modules": [
@@ -43,39 +57,22 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
-      "keycloakOptions": {
-        "host": "identitydev.iudx.io",
-        "port": 8443,
-        "uri": "/auth/realms/demo/protocol/openid-connect/token",
-        "clientId": "auth.iudx.org.in",
-        "clientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3"
-      }
+      "keystorePassword": "secret"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
      {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
@@ -92,16 +89,10 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
-      "corsRegexString": "*",
-      "keycloakOptions": {
-        "site": "https://<host>:<port>/auth/realms/demo",
-        "clientId": "keycloakClientId",
-        "clientSecret": "keycloakClientSecret",
-        "jwtLeeway": 90
-      }
+      "corsRegexString": "*"
     }
   ]
 }

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -5,15 +5,20 @@
   ],
   "clusterId": "iudx-aaa-cluster",
   "databaseSchema":"test",
+  "options":{
+      "postgresOptions": {
+        "databaseIP": "139.59.80.176",
+        "databasePort": "5432",
+        "databaseName": "iudx",
+        "databaseUserName": "iudx_user",
+        "databasePassword": "iudx@123"
+      }
+  },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "domain" : "iudx.io",
       "catalogueOptions": {
@@ -37,11 +42,7 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -53,11 +54,7 @@
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
       "authServerDomain": "auth.test.com",
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -75,11 +72,7 @@
       "options": {
         "authServerDomain": "foobar.iudx.io"
       },
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -103,11 +96,7 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -29,6 +29,10 @@
         "keycloakAaaClientId": "auth.iudx.org.in",
         "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
         "keycloakJwtLeeway": 90
+      },
+      "jwtKeystoreOptions":{
+        "keystorePath": "configs/keystore.jks",
+        "keystorePassword": "secret"
       }
   },
   "modules": [
@@ -63,10 +67,8 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
-      "poolSize": "5",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
+      "poolSize": "5"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
@@ -86,10 +88,8 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*"

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -15,6 +15,20 @@
       },
       "commonOptions":{
         "authServerDomain":"auth.test.com"
+      },
+      "keycloakOptions":{
+        "keycloakHost": "identitydev.iudx.io",
+        "keycloakPort": 8443,
+        "keycloakRealm": "some-realm",
+        "keycloakSite": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth/realms/{{keycloakRealm}}",
+        "keycloakUrl": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth",
+        "keycloakTokenUri": "/auth/realms/{{keycloakRealm}}/protocol/openid-connect/token",
+        "keycloakAdminClientId": "some-admin-client-id",
+        "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
+        "keycloakAdminPoolSize": "10",
+        "keycloakAaaClientId": "auth.iudx.org.in",
+        "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
+        "keycloakJwtLeeway": 90
       }
   },
   "modules": [
@@ -43,39 +57,22 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
-      "poolSize": "5",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "keycloakOptions"],
+      "poolSize": "5"
     },
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
-      "keycloakOptions": {
-        "host": "iudx.keycloack.io",
-        "port": 8443,
-        "uri": "/auth/realms/demo/protocol/openid-connect/token",
-        "clientId": "keycloackClientId",
-        "clientSecret": "keycloackClientSecret"
-      }
+      "keystorePassword": "secret"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
-      "poolSize": "5",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "poolSize": "5"
     },
      {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
@@ -92,16 +89,10 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
-      "corsRegexString": "*",
-      "keycloakOptions": {
-        "site": "https://<host>:<port>/auth/realms/demo",
-        "clientId": "keycloakClientId",
-        "clientSecret": "keycloakClientSecret",
-        "jwtLeeway": 90
-      }
+      "corsRegexString": "*"
     }
   ]
 }

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -12,22 +12,23 @@
         "databaseName": "iudx",
         "databaseUserName": "iudx_user",
         "databasePassword": "iudx@123"
+      },
+      "commonOptions":{
+        "authServerDomain":"auth.test.com"
       }
   },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443",
-        "authServerUrl": "authdev.iudx.io"
+        "catServerPort": "443"
       },
       "authOptions": {
-        "authServerUrl": "authdev.iudx.io",
         "policyExpiry" : "12",
         "adminPolicyExpiry" : "60"
       },
@@ -53,8 +54,7 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "authServerDomain": "auth.test.com",
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -69,10 +69,7 @@
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "options": {
-        "authServerDomain": "foobar.iudx.io"
-      },
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -92,11 +89,10 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "authServerDomain": "auth.test.com",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -15,6 +15,20 @@
       },
       "commonOptions":{
         "authServerDomain":"auth.test.com"
+      },
+      "keycloakOptions":{
+        "keycloakHost": "identitydev.iudx.io",
+        "keycloakPort": 8443,
+        "keycloakRealm": "some-realm",
+        "keycloakSite": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth/realms/{{keycloakRealm}}",
+        "keycloakUrl": "{{protocol}}://{{keycloakHost}}:{{keycloakPort}}/auth",
+        "keycloakTokenUri": "/auth/realms/{{keycloakRealm}}/protocol/openid-connect/token",
+        "keycloakAdminClientId": "some-admin-client-id",
+        "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
+        "keycloakAdminPoolSize": "10",
+        "keycloakAaaClientId": "auth.iudx.org.in",
+        "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
+        "keycloakJwtLeeway": 90
       }
   },
   "modules": [
@@ -43,39 +57,22 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
-      "keycloakOptions": {
-        "host": "keycloakHost",
-        "port": 8443,
-        "uri": "/auth/realms/demo/protocol/openid-connect/token",
-        "clientId": "keycloackClientId",
-        "clientSecret": "keycloackClientSecret"
-      }
+      "keystorePassword": "secret"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
-      "poolSize": "25",
-      "keycloakUrl": "https://127.0.0.1:3000/auth",
-      "keycloakRealm": "some-realm",
-      "keycloakAdminClientId": "some-admin-client-id",
-      "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
-      "keycloakAdminPoolSize": "10"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "poolSize": "25"
     },
      {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
@@ -92,16 +89,10 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
-      "corsRegexString": "*",
-      "keycloakOptions": {
-        "site": "https://<host>:<port>/auth/realms/demo",
-        "clientId": "keycloakClientId",
-        "clientSecret": "keycloakClientSecret",
-        "jwtLeeway": 90
-      }
+      "corsRegexString": "*"
     }
   ]
 }

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -29,6 +29,10 @@
         "keycloakAaaClientId": "auth.iudx.org.in",
         "keycloakAaaClientSecret": "6ba618a0-06c6-49a0-a824-d5dfc6d025f3",
         "keycloakJwtLeeway": 90
+      },
+      "jwtKeystoreOptions":{
+        "keystorePath": "configs/keystore.jks",
+        "keystorePassword": "secret"
       }
   },
   "modules": [
@@ -63,10 +67,8 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
-      "poolSize": "5",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret"
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
+      "poolSize": "5"
     },
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
@@ -86,10 +88,8 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "keystorePath": "configs/keystore.jks",
-      "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions", "commonOptions", "keycloakOptions"],
+      "required":["postgresOptions", "commonOptions", "keycloakOptions", "jwtKeystoreOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*"

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -12,22 +12,23 @@
         "databaseName": "iudx",
         "databaseUserName": "iudx_user",
         "databasePassword": "iudx@123"
+      },
+      "commonOptions":{
+        "authServerDomain":"auth.test.com"
       }
   },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443",
-        "authServerUrl": "authdev.iudx.io"
+        "catServerPort": "443"
       },
       "authOptions": {
-        "authServerUrl": "authdev.iudx.io",
         "policyExpiry" : "12",
         "adminPolicyExpiry" : "60"
       },
@@ -53,8 +54,7 @@
     {
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
-      "authServerDomain": "auth.test.com",
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -69,10 +69,7 @@
     {
       "id": "iudx.aaa.server.admin.AdminVerticle",
       "verticleInstances": 1,
-      "options": {
-        "authServerDomain": "foobar.iudx.io"
-      },
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -92,11 +89,10 @@
     },
     {
       "id": "iudx.aaa.server.apiserver.ApiServerVerticle",
-      "authServerDomain": "auth.test.com",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "required":["postgresOptions"],
+      "required":["postgresOptions", "commonOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -5,15 +5,20 @@
   ],
   "clusterId": "iudx-aaa-cluster",
   "databaseSchema":"test",
+  "options":{
+      "postgresOptions": {
+        "databaseIP": "139.59.80.176",
+        "databasePort": "5432",
+        "databaseName": "iudx",
+        "databaseUserName": "iudx_user",
+        "databasePassword": "iudx@123"
+      }
+  },
   "modules": [
     {
       "id": "iudx.aaa.server.policy.PolicyVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "domain" : "iudx.io",
       "catalogueOptions": {
@@ -37,11 +42,7 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -53,11 +54,7 @@
       "id": "iudx.aaa.server.token.TokenVerticle",
       "verticleInstances": 1,
       "authServerDomain": "auth.test.com",
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
@@ -75,11 +72,7 @@
       "options": {
         "authServerDomain": "foobar.iudx.io"
       },
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "25",
       "keycloakUrl": "https://127.0.0.1:3000/auth",
       "keycloakRealm": "some-realm",
@@ -87,7 +80,7 @@
       "keycloakAdminClientSecret": "f5800be0-258a-4cd2-820f-8128818ed70a",
       "keycloakAdminPoolSize": "10"
     },
-    {
+     {
       "id": "iudx.aaa.server.auditing.AuditingVerticle",
       "verticleInstances": 1,
       "auditingDatabaseIP": "",
@@ -103,11 +96,7 @@
       "keystorePath": "configs/keystore.jks",
       "keystorePassword": "secret",
       "verticleInstances": 1,
-      "databaseIP": "139.59.80.176",
-      "databasePort": "5432",
-      "databaseName": "iudx",
-      "databaseUserName": "iudx_user",
-      "databasePassword": "iudx@123",
+      "required":["postgresOptions"],
       "poolSize": "5",
       "serverTimeoutMs": 5000,
       "corsRegexString": "*",

--- a/src/main/java/iudx/aaa/server/admin/AdminVerticle.java
+++ b/src/main/java/iudx/aaa/server/admin/AdminVerticle.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.admin;
 
+import static iudx.aaa.server.admin.Constants.CONFIG_AUTH_URL;
 import static iudx.aaa.server.admin.Constants.DATABASE_IP;
 import static iudx.aaa.server.admin.Constants.DATABASE_NAME;
 import static iudx.aaa.server.admin.Constants.DATABASE_PASSWORD;
@@ -90,7 +91,9 @@ public class AdminVerticle extends AbstractVerticle {
     keycloakAdminClientSecret = config().getString(KC_ADMIN_CLIENT_SEC);
     keycloakAdminPoolSize = Integer.parseInt(config().getString(KC_ADMIN_POOLSIZE));
 
-    options = config().getJsonObject("options");
+    /* Pass an `options` JSON object to the serviceImpl with a key:val being the
+     * authServerDomain */
+    options = new JsonObject().put(CONFIG_AUTH_URL, config().getString(CONFIG_AUTH_URL));
 
     /* Set Connection Object */
     if (connectOptions == null) {

--- a/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
@@ -157,7 +157,9 @@ public class ApiServerVerticle extends AbstractVerticle {
     allowedMethods.add(HttpMethod.PATCH);
     allowedMethods.add(HttpMethod.PUT);
 
-    OIDCAuthentication oidcFlow = new OIDCAuthentication(vertx, pgPool, keycloakOptions);
+    /* Passing the full config to OIDC auth, as the config has all the required keycloak
+     * options */
+    OIDCAuthentication oidcFlow = new OIDCAuthentication(vertx, pgPool, config());
     ClientAuthentication clientFlow = new ClientAuthentication(pgPool);
     ProviderAuthentication providerAuth = new ProviderAuthentication(pgPool, authServerDomain);
     SearchUserHandler searchUser = new SearchUserHandler();

--- a/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
@@ -22,6 +22,8 @@ public class Constants {
   public static final String HEADER_PROVIDER_ID = "providerId";
   public static final String HEADER_EMAIL = "email";
   public static final String HEADER_ROLE = "role";
+  public static final String CLIENT_ID = "clientId";
+  public static final String CLIENT_SECRET = "clientSecret";
 
   /* Configuration & related */
   public static final String DATABASE_IP = "databaseIP";
@@ -121,11 +123,12 @@ public class Constants {
   public static final String ID = "id";
   public static final String ROLES = "roles";
   public static final String USER = "user";
-  public static final String CLIENT_ID = "clientId";
-  public static final String CLIENT_SECRET = "clientSecret";
+  public static final String KEYCLOAK_AAA_SERVER_CLIENT_ID = "keycloakAaaClientId";
+  public static final String KEYCLOAK_AAA_SERVER_CLIENT_SECRET = "keycloakAaaClientSecret";
   public static final String KID = "kid";
-  public static final String SITE = "site";
-  public static final String JWT_LEEWAY = "jwtLeeway";
+  public static final String KEYCLOAK_SITE = "keycloakSite";
+  public static final String KEYCLOAK_REALM = "keycloakRealm";
+  public static final String KEYCLOAK_JWT_LEEWAY = "keycloakJwtLeeway";
   public static final String STATUS = "status";
   public static final String SSL = "ssl";
   public static final String KS_ALIAS = "ES256";

--- a/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
@@ -139,16 +139,19 @@ public class OIDCAuthentication implements AuthenticationHandler {
 
   /**
    * Creates KeyCloack provider using configurations.
+   * keycloakOptions is a JSON object containing the required
+   * keys. (It is actually the full config verticle config object)
    */
   public void keyCloackAuth() {
-    String site = keycloakOptions.getString(SITE);
-    String realm = site.substring(site.lastIndexOf('/') + 1);
+    String site = keycloakOptions.getString(KEYCLOAK_SITE);
+    String realm = keycloakOptions.getString(KEYCLOAK_REALM);
 
     /* Options for OAuth2, KeyCloack. */
     OAuth2Options options = new OAuth2Options().setFlow(OAuth2FlowType.CLIENT)
-        .setClientID(keycloakOptions.getString(CLIENT_ID))
-        .setClientSecret(keycloakOptions.getString(CLIENT_SECRET)).setTenant(realm).setSite(site)
-        .setJWTOptions(new JWTOptions().setLeeway(keycloakOptions.getInteger(JWT_LEEWAY)));
+        .setClientID(keycloakOptions.getString(KEYCLOAK_AAA_SERVER_CLIENT_ID))
+        .setClientSecret(keycloakOptions.getString(KEYCLOAK_AAA_SERVER_CLIENT_SECRET))
+        .setTenant(realm).setSite(site)
+        .setJWTOptions(new JWTOptions().setLeeway(keycloakOptions.getInteger(KEYCLOAK_JWT_LEEWAY)));
 
     options.getHttpClientOptions().setSsl(true).setVerifyHost(false).setTrustAll(true);
 

--- a/src/main/java/iudx/aaa/server/deploy/ConfigResolve.java
+++ b/src/main/java/iudx/aaa/server/deploy/ConfigResolve.java
@@ -1,0 +1,31 @@
+package iudx.aaa.server.deploy;
+
+import java.util.Iterator;
+import io.vertx.core.json.JsonObject;
+
+public class ConfigResolve {
+
+  public static JsonObject resolve(JsonObject config) throws IllegalStateException {
+
+    JsonObject options = config.getJsonObject("options");
+    Iterator<Object> iterateModules = config.getJsonArray("modules").iterator();
+    while (iterateModules.hasNext()) {
+      JsonObject module = (JsonObject) iterateModules.next();
+      
+      if (!module.containsKey("required")) {
+        continue;
+      }
+      
+      Iterator<Object> iterateOptions = module.getJsonArray("required").iterator();
+      while (iterateOptions.hasNext()) {
+        String option = (String) iterateOptions.next();
+        if (!options.containsKey(option)) {
+          throw new IllegalStateException("Option not found " + option);
+        }
+        module.mergeIn(options.getJsonObject(option));
+      }
+    }
+
+    return config;
+  }
+}

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -193,6 +193,14 @@ public class Deployer {
     VertxOptions options = new VertxOptions().setClusterManager(mgr).setEventBusOptions(ebOptions)
         .setMetricsOptions(getMetricsOptions());
     LOGGER.debug("metrics-options" + options.getMetricsOptions());
+    try {
+      ConfigResolve.resolve(configuration);
+    }
+    catch(IllegalStateException e)
+    {
+      LOGGER.fatal("Invalid option passed in config" + e.getMessage());
+      return;
+    }
     String dbSchema = configuration.getString("databaseSchema");
     Schema.INSTANCE.set(dbSchema);
     LOGGER.debug("Set database schema to " + Schema.INSTANCE);

--- a/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
+++ b/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
@@ -75,6 +75,14 @@ public class DeployerDev {
     String dbSchema = configuration.getString("databaseSchema");
     Schema.INSTANCE.set(dbSchema);
     LOGGER.debug("Set database schema to " + Schema.INSTANCE);
+    try {
+      ConfigResolve.resolve(configuration);
+    }
+    catch(IllegalStateException e)
+    {
+      LOGGER.fatal("Invalid option passed in config" + e.getMessage());
+      return;
+    }
     Vertx vertx = Vertx.vertx(options);
     recursiveDeploy(vertx, configuration, 0);
   }

--- a/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
@@ -74,6 +74,12 @@ public class PolicyVerticle extends AbstractVerticle {
     authOptions = config().getJsonObject("authOptions");
     catOptions = config().getJsonObject("catOptions");
 
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", config().getString("authServerDomain"));
+    catOptions.put("authServerUrl", config().getString("authServerDomain"));
 
     //get options for catalogue client
 

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -28,7 +28,12 @@ public class Constants {
   public static final String KEYSTORE_PATH = "keystorePath";
   public static final String KEYSTPRE_PASSWORD = "keystorePassword";
   public static final String AUTHSERVER_DOMAIN = "authServerDomain";
-  public static final String KEYCLOACK_OPTIONS = "keycloakOptions";
+
+  public static final String KEYCLOAK_HOST = "keycloakHost";
+  public static final String KEYCLOAK_PORT = "keycloakPort";
+  public static final String KEYCLOAK_TOKEN_URI = "keycloakTokenUri";
+  public static final String KEYCLOAK_AAA_SERVER_CLIENT_ID = "keycloakAaaClientId";
+  public static final String KEYCLOAK_AAA_SERVER_CLIENT_SECRET = "keycloakAaaClientSecret";
   public static final int PG_CONNECTION_TIMEOUT = 10000;
   
   /* General */ 
@@ -40,6 +45,7 @@ public class Constants {
   public static final String DESC = "desc";
   public static final String ACCESS_TOKEN = "accessToken";
   public static final String RS_URL = "rsUrl";
+  public static final String HOST = "host";
   public static final String PORT = "port";
   public static final String URI = "uri";
   public static final String BODY = "BODY";

--- a/src/main/java/iudx/aaa/server/token/TokenRevokeService.java
+++ b/src/main/java/iudx/aaa/server/token/TokenRevokeService.java
@@ -105,18 +105,18 @@ public class TokenRevokeService {
    * To Generate JWT using KeyCloak credentials.
    * Performs POST Multipart/Form request to KeyCloak.
    * 
-   * @param requestBody which is a JsonObject
+   * @param config which is a JsonObject with the keycloak config
    * @return promise and future associated with the promise.
    */
-  private Future<JsonObject> httpPostFormAsync(JsonObject requestBody) {
+  private Future<JsonObject> httpPostFormAsync(JsonObject config) {
 
     Promise<JsonObject> promise = Promise.promise();
-    RequestOptions options = new RequestOptions(requestBody);
+    RequestOptions options = new RequestOptions(config);
     
     MultiMap bodyForm = MultiMap.caseInsensitiveMultiMap();
     bodyForm.set(GRANT_TYPE, CLIENT_CREDENTIALS)
-            .set("client_id", requestBody.getString(CLIENT_ID))
-            .set("client_secret", requestBody.getString(CLIENT_SECRET));
+            .set("client_id", config.getString(CLIENT_ID))
+            .set("client_secret", config.getString(CLIENT_SECRET));
     
     client.request(HttpMethod.POST, options).sendForm(bodyForm, reqHandler -> {
       if (reqHandler.succeeded()) {

--- a/src/main/java/iudx/aaa/server/token/TokenVerticle.java
+++ b/src/main/java/iudx/aaa/server/token/TokenVerticle.java
@@ -68,7 +68,17 @@ public class TokenVerticle extends AbstractVerticle {
     keystorePath = config().getString(KEYSTORE_PATH);
     keystorePassword = config().getString(KEYSTPRE_PASSWORD);
     String issuer = config().getString(AUTHSERVER_DOMAIN,"");
-    JsonObject keycloakOptions = config().getJsonObject(KEYCLOACK_OPTIONS);
+
+    /* keycloakOptions contains the configuration options to get a token from Keycloak
+     * along with the client ID and client secret of the AAA server. This is created 
+     * since the httpPostFormAsync method in TokenRevokeService uses the object as is 
+     * for configuring the web client request options (host, port, uri). */
+    JsonObject keycloakOptions = new JsonObject()
+        .put(HOST, config().getString(KEYCLOAK_HOST))
+        .put(PORT, config().getString(KEYCLOAK_PORT))
+        .put(URI, config().getString(KEYCLOAK_TOKEN_URI))
+        .put(CLIENT_ID, config().getString(KEYCLOAK_AAA_SERVER_CLIENT_ID))
+        .put(CLIENT_SECRET, config().getString(KEYCLOAK_AAA_SERVER_CLIENT_SECRET));
     
     if(issuer != null && !issuer.isBlank()) {
       CLAIM_ISSUER = issuer;

--- a/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
@@ -71,6 +71,13 @@ public class CreateDelegationsTest {
         authOptions = dbConfig.getJsonObject("authOptions");
         catOptions = dbConfig.getJsonObject("catOptions");
 
+        /*
+         * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+         * TODO - make this uniform
+         */
+        authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+        catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+        
 // Set Connection Object
 
         if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
@@ -70,6 +70,12 @@ public class CreatePolicyTest {
     authOptions = dbConfig.getJsonObject("authOptions");
     catOptions = dbConfig.getJsonObject("catOptions");
 
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     /* Set Connection Object */
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
@@ -129,6 +129,13 @@ public class DeleteDelegationTest {
     poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
     authOptions = dbConfig.getJsonObject("authOptions");
     catOptions = dbConfig.getJsonObject("catOptions");
+    
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     // Set Connection Object
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
@@ -66,6 +66,13 @@ public class DeletePolicyTest {
     poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
       authOptions = dbConfig.getJsonObject("authOptions");
       catOptions = dbConfig.getJsonObject("catOptions");
+      
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     /* Set Connection Object */
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
@@ -119,6 +119,13 @@ public class ListDelegationTest {
     poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
     authOptions = dbConfig.getJsonObject("authOptions");
     catOptions = dbConfig.getJsonObject("catOptions");
+    
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     // Set Connection Object
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -70,6 +70,13 @@ public class ListPolicyTest {
         poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
         authOptions = dbConfig.getJsonObject("authOptions");
         catOptions = dbConfig.getJsonObject("catOptions");
+        
+        /*
+         * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+         * TODO - make this uniform
+         */
+        authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+        catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
 // Set Connection Object
 

--- a/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
@@ -66,6 +66,12 @@ public class VerifyPolicyTest {
     authOptions = dbConfig.getJsonObject("authOptions");
     catOptions = dbConfig.getJsonObject("catOptions");
 
+    /*
+     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * TODO - make this uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
       /* Set Connection Object */
     if (connectOptions == null) {


### PR DESCRIPTION
- configs now have an `options` JSON object. This object can contain config options
that are repeated across verticles
- Each verticle in the `modules` array can have a `required` key which is a JSON array.
The array contains the names of the keys present in the `options` object
- Before deployment, the `required` array for each verticle in `modules`
is inspected and the required config options are merged together

ConfigResolve
-------------
* The `resolve` method merges the required config options for each verticle

Deployer, DeployerDev, Configuration
------------------------------------
* Run ConfigResolve.resolve() before deploying

configs/*
---------
* Add the `options` object
* Add `required` array for all verticles
* Place postgres config in the `options` object and add `postgresOptions` in
required array for all verticles