### PR TITLE
Patch to log4j2 RCE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
-		<apache-log4j-core.version>2.14.1</apache-log4j-core.version>
+		<apache-log4j-core.version>2.15.0</apache-log4j-core.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -303,6 +303,7 @@ public class Deployer {
                 + "If omitted, or if `all` is passed, all verticles are deployed"));
 
     StringBuilder usageString = new StringBuilder();
+    LOGGER.debug("The logger has message lookups disabled ${LOG_LEVEL_PATTERN}");
     cli.usage(usageString);
     CommandLine commandLine = cli.parse(Arrays.asList(args), false);
     if (commandLine.isValid() && !commandLine.isFlagEnabled("help")) {

--- a/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
+++ b/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
@@ -93,7 +93,7 @@ public class DeployerDev {
             .setDescription("display help"))
         .addOption(new Option().setLongName("config").setShortName("c")
             .setRequired(true).setDescription("configuration file"));
-
+    LOGGER.debug("The logger has message lookups disabled ${LOG_LEVEL_PATTERN}");
     StringBuilder usageString = new StringBuilder();
     cli.usage(usageString);
     CommandLine commandLine = cli.parse(Arrays.asList(args), false);


### PR DESCRIPTION
1) It solves the CVE reported at
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
Detailed at https://www.lunasec.io/docs/blog/log4j-zero-day/
2) It is mitigated by upgrading log4j2 from 2.14.1 to 2.15.0, which
disables MsgLookups by default
Detailed at
https://logging.apache.org/log4j/2.x/changes-report.html#a2.15.0
3) A debug statement with property lookup is added in log message to
verify no lookups is done in log message.

The release 2.15.0  is released in [maven central](https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/)