### PR TITLE
Bugfix - Add authServerUrl key to `catalogueOptions` instead of `catOptions`

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
@@ -75,11 +75,11 @@ public class PolicyVerticle extends AbstractVerticle {
     catOptions = config().getJsonObject("catOptions");
 
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' and 'catalogueOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", config().getString("authServerDomain"));
-    catOptions.put("authServerUrl", config().getString("authServerDomain"));
+    catalogueOptions.put("authServerUrl", config().getString("authServerDomain"));
 
     //get options for catalogue client
 

--- a/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
@@ -72,11 +72,10 @@ public class CreateDelegationsTest {
         catOptions = dbConfig.getJsonObject("catOptions");
 
         /*
-         * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+         * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
          * TODO - make this uniform
          */
         authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-        catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
         
 // Set Connection Object
 

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
@@ -71,11 +71,10 @@ public class CreatePolicyTest {
     catOptions = dbConfig.getJsonObject("catOptions");
 
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     /* Set Connection Object */
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
@@ -131,11 +131,10 @@ public class DeleteDelegationTest {
     catOptions = dbConfig.getJsonObject("catOptions");
     
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     // Set Connection Object
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
@@ -68,11 +68,10 @@ public class DeletePolicyTest {
       catOptions = dbConfig.getJsonObject("catOptions");
       
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     /* Set Connection Object */
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
@@ -121,11 +121,10 @@ public class ListDelegationTest {
     catOptions = dbConfig.getJsonObject("catOptions");
     
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     // Set Connection Object
     if (connectOptions == null) {

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -72,11 +72,10 @@ public class ListPolicyTest {
         catOptions = dbConfig.getJsonObject("catOptions");
         
         /*
-         * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+         * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
          * TODO - make this uniform
          */
         authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-        catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
 // Set Connection Object
 

--- a/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
@@ -67,11 +67,10 @@ public class VerifyPolicyTest {
     catOptions = dbConfig.getJsonObject("catOptions");
 
     /*
-     * Injecting authServerUrl into 'authOptions' and 'catOptions' from config().'authServerDomain'
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
      * TODO - make this uniform
      */
     authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
-    catOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
       /* Set Connection Object */
     if (connectOptions == null) {


### PR DESCRIPTION
…ptions`

- In commit ec24a4fbdbd7965a1ec68e035ec77f639af67319, 'authServerUrl' was removed from
'catalogueOptions' in all configs, and was then mistakenly being injected into
catOptions'
- Now correctly injecting it into `catalogueOptions` in PolicyVerticle
- Removing `authServerUrl` injection into catOptions from all tests