### PR TITLE
Update token revoke API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -511,23 +511,15 @@ paths:
               description: ''
               type: object
               properties:
-                clientId:
-                  type: string
-                  minLength: 36
-                  format: uuid
-                  pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
-                  maxLength: 36
                 rsUrl:
                   type: string
                   minLength: 1
               required:
-                - clientId
                 - rsUrl
             examples:
               Revoke Request:
                 value:
-                  clientId: 123e4567-e89b-12d3-a456-426614174000
-                  rsUrl: string
+                  rsUrl: rs.iudx.org.in
         required: true
       security:
         - authorization: []

--- a/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
@@ -386,16 +386,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     JsonObject tokenRequestJson = context.getBodyAsJson();
     RevokeToken revokeTokenDTO = tokenRequestJson.mapTo(RevokeToken.class);
 
-    String dbClientId = context.get(CLIENT_ID);
     User user = context.get(USER);
-
-    if (!dbClientId.equals(revokeTokenDTO.getClientId())) {
-      LOGGER.error("Fail: " + INVALID_CLIENT);
-      Response resp = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
-          .title(INVALID_CLIENT).detail(INVALID_CLIENT).build();
-      processResponse(context.response(), resp.toJson());
-      return;
-    }
 
     tokenService.revokeToken(revokeTokenDTO, user, handler -> {
       if (handler.succeeded()) {

--- a/src/main/java/iudx/aaa/server/apiserver/RevokeToken.java
+++ b/src/main/java/iudx/aaa/server/apiserver/RevokeToken.java
@@ -10,9 +10,6 @@ import io.vertx.core.json.JsonObject;
 //@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class RevokeToken {
 
-  @JsonAlias("clientId")
-  private String clientId;
-
   @JsonAlias("rsUrl")
   private String rsUrl;
 
@@ -28,14 +25,6 @@ public class RevokeToken {
   }
 
   public RevokeToken() {}
-
-  public String getClientId() {
-    return clientId;
-  }
-
-  public void setClientId(String clientId) {
-    this.clientId = clientId;
-  }
 
   public String getRsUrl() {
     return rsUrl;

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -15,7 +15,8 @@ public class Constants {
   public static String CLAIM_ISSUER = "";
   public static final long CLAIM_EXPIRY = 60 * 60 * 12; //In Seconds 
   
-  public static final String RS_REVOKE_URN = "/token/revocation";
+  public static final String RS_REVOKE_URI = "/admin/tokenRevoke";
+  public static final String RS_REVOKE_BODY_SUB = "sub";
   public static final int DEFAULT_HTTPS_PORT = 443;
   
   /* Configuration & related */

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -112,6 +112,7 @@ public class Constants {
   public static final String INTERNAL_SVR_ERR = "Internal server error";
   public static final String INVALID_CLIENT_ID_SEC = "Invalid clientId/clientSecret";
   public static final String INVALID_ROLE = "Role not defined";
+  public static final String CANNOT_REVOKE_ON_AUTH = "Cannot revoke tokens on auth server";
   public static final String INVALID_POLICY = "Policy evaluation failed";
   public static final String TOKEN_SUCCESS = "Token created";
   public static final String TOKEN_REVOKED = "Token revoked";

--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -285,6 +285,18 @@ public class TokenServiceImpl implements TokenService {
 
       JsonObject accessTokenJwt = jwtDetails.attributes().getJsonObject(ACCESS_TOKEN);
       String userId = accessTokenJwt.getString(SUB);
+      
+      /* If the sub field is equal to the auth server domain, it is a
+       * special admin token. Immediately send the decoded JWT back, as
+       * there is no role/item information to be checked/validated.
+       */
+      if(userId.equals(CLAIM_ISSUER)) {
+        Response resp = new ResponseBuilder().status(200).type(URN_SUCCESS)
+            .title(TOKEN_AUTHENTICATED).objectResults(accessTokenJwt).build();
+        handler.handle(Future.succeededFuture(resp.toJson()));
+        return;
+      }
+      
       String role = accessTokenJwt.getString(ROLE);
       
       String[] item = accessTokenJwt.getString(IID).split(":");

--- a/src/main/java/iudx/aaa/server/token/TokenVerticle.java
+++ b/src/main/java/iudx/aaa/server/token/TokenVerticle.java
@@ -69,17 +69,6 @@ public class TokenVerticle extends AbstractVerticle {
     keystorePassword = config().getString(KEYSTPRE_PASSWORD);
     String issuer = config().getString(AUTHSERVER_DOMAIN,"");
 
-    /* keycloakOptions contains the configuration options to get a token from Keycloak
-     * along with the client ID and client secret of the AAA server. This is created 
-     * since the httpPostFormAsync method in TokenRevokeService uses the object as is 
-     * for configuring the web client request options (host, port, uri). */
-    JsonObject keycloakOptions = new JsonObject()
-        .put(HOST, config().getString(KEYCLOAK_HOST))
-        .put(PORT, config().getString(KEYCLOAK_PORT))
-        .put(URI, config().getString(KEYCLOAK_TOKEN_URI))
-        .put(CLIENT_ID, config().getString(KEYCLOAK_AAA_SERVER_CLIENT_ID))
-        .put(CLIENT_SECRET, config().getString(KEYCLOAK_AAA_SERVER_CLIENT_SECRET));
-    
     if(issuer != null && !issuer.isBlank()) {
       CLAIM_ISSUER = issuer;
     } else {
@@ -101,7 +90,7 @@ public class TokenVerticle extends AbstractVerticle {
         
     /* Initializing the services */
     provider = jwtInitConfig();
-    revokeService = new TokenRevokeService(vertx, keycloakOptions);
+    revokeService = new TokenRevokeService(vertx);
     pgPool = PgPool.pool(vertx, connectOptions, poolOptions);
     policyService = PolicyService.createProxy(vertx, POLICY_SERVICE_ADDRESS);
     tokenService = new TokenServiceImpl(pgPool, policyService, provider, revokeService);

--- a/src/test/java/iudx/aaa/server/token/MockHttpWebClient.java
+++ b/src/test/java/iudx/aaa/server/token/MockHttpWebClient.java
@@ -35,9 +35,9 @@ public class MockHttpWebClient {
 
     asyncResult = Mockito.mock(AsyncResult.class);
     Mockito.doAnswer((Answer<AsyncResult<JsonObject>>) arguments -> {
-      ((Handler<AsyncResult<JsonObject>>) arguments.getArgument(1)).handle(asyncResult);
+      ((Handler<AsyncResult<JsonObject>>) arguments.getArgument(2)).handle(asyncResult);
       return null;
-    }).when(httpWebClient).httpRevokeRequest(Mockito.any(), Mockito.any());
+    }).when(httpWebClient).httpRevokeRequest(Mockito.any(),Mockito.any(), Mockito.any());
     
     return MockHttpWebClient.httpWebClient;
     

--- a/src/test/java/iudx/aaa/server/token/RequestPayload.java
+++ b/src/test/java/iudx/aaa/server/token/RequestPayload.java
@@ -17,12 +17,9 @@ import iudx.aaa.server.apiserver.User.UserBuilder;
  */
 public class RequestPayload {
   
-  /* Payload for tokenRevoke */
   public static JsonObject revokeTokenValidPayload = new JsonObject().put("clientId", "349b4b55-0251-490e-bee9-00f3a5d3e643")
       .put("rsUrl", "foobar.iudx.io");
 
-  public static JsonObject revokeTokenInvalidClientId =new JsonObject().put("clientId", "149b4b55-0251-490e-bee9-00f3a5d3e643");
-  public static JsonObject revokeTokenInvalidUrl = revokeTokenValidPayload.copy().put("rsUrl", "barfoo.iudx.io");
   
   /* Payload for TIP */
   public static JsonObject expiredTipPayload = new JsonObject().put("accessToken", "eyJ0eXAiOiJKV1QiL"

--- a/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
+++ b/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
@@ -13,6 +13,7 @@ import static iudx.aaa.server.token.Constants.ITEM_TYPE;
 import static iudx.aaa.server.token.Constants.PG_CONNECTION_TIMEOUT;
 import static iudx.aaa.server.token.Constants.RESOURCE_SVR;
 import static iudx.aaa.server.token.Constants.ROLE;
+import static iudx.aaa.server.token.Constants.RS_URL;
 import static iudx.aaa.server.token.Constants.STATUS;
 import static iudx.aaa.server.token.Constants.TYPE;
 import static iudx.aaa.server.token.Constants.URL;
@@ -26,9 +27,6 @@ import static iudx.aaa.server.token.RequestPayload.expiredTipPayload;
 import static iudx.aaa.server.token.RequestPayload.mapToInspctToken;
 import static iudx.aaa.server.token.RequestPayload.mapToRevToken;
 import static iudx.aaa.server.token.RequestPayload.randomToken;
-import static iudx.aaa.server.token.RequestPayload.revokeTokenInvalidClientId;
-import static iudx.aaa.server.token.RequestPayload.revokeTokenInvalidUrl;
-import static iudx.aaa.server.token.RequestPayload.revokeTokenValidPayload;
 import static iudx.aaa.server.token.RequestPayload.user;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -503,10 +501,17 @@ public class TokenServiceTest {
   @Test
   @DisplayName("revokeToken [Success]")
   void revokeTokenSuccess(VertxTestContext testContext) {
+    JsonObject userJson = consumer.result();
+    
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
 
+    JsonObject request = new JsonObject().put(RS_URL, DUMMY_SERVER);
+    
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
-        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_SUCCESS, response.getString(TYPE));
           testContext.completeNow();
@@ -514,44 +519,67 @@ public class TokenServiceTest {
   }
 
   @Test
-  @DisplayName("revokeToken [Failed-01 Failure in KeyClock or RS]")
+  @DisplayName("revokeToken [Failed-01 Failure in RS]")
   void revokeTokenFailed01(VertxTestContext testContext) {
 
+    JsonObject userJson = consumer.result();
+    
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject request = new JsonObject().put(RS_URL, DUMMY_SERVER);
     mockHttpWebClient.setResponse("invalid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
-        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(400, response.getInteger(STATUS));
           testContext.completeNow();
         })));
   }
 
   @Test
-  @Disabled
-  @DisplayName("revokeToken [Failed-02 nullUserId]")
+  @DisplayName("revokeToken [Failed-02 no roles]")
   void revokeTokenFailed02(VertxTestContext testContext) {
 
     mockHttpWebClient.setResponse("valid");
-    User.UserBuilder userBuilder = new UserBuilder();
-    User user = new User(userBuilder);
+    
+    JsonObject userJson = consumer.result();
+    
+    /* We purposefully add no roles to the user object */
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of()).build();
 
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload), user,
+    JsonObject request = new JsonObject().put(RS_URL, DUMMY_SERVER);
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(400, response.getInteger(STATUS));
           testContext.completeNow();
         })));
   }
 
   @Test
-  @Disabled
-  @DisplayName("revokeToken [Failed-03 invalidUserId]")
+  @DisplayName("revokeToken [Failed-03 nilUUID userId]")
   void revokeTokenFailed03(VertxTestContext testContext) {
 
+    JsonObject userJson = consumer.result();
+    
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(NIL_UUID.toString())
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject request = new JsonObject().put(RS_URL, DUMMY_SERVER);
+
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenValidPayload),
-        user("32a4b979-4f4a-4c44-b0c3-2fe109952b53"),
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_MISSING_INFO, response.getString(TYPE));
+          assertEquals(404, response.getInteger(STATUS));
           testContext.completeNow();
         })));
   }
@@ -559,10 +587,17 @@ public class TokenServiceTest {
   @Test
   @DisplayName("revokeToken [Failed-04 invalidUrl]")
   void revokeTokenFailed04(VertxTestContext testContext) {
+    JsonObject userJson = consumer.result();
+    
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject request = new JsonObject().put(RS_URL, "abcd.com");
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidUrl),
-        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();
@@ -570,12 +605,19 @@ public class TokenServiceTest {
   }
 
   @Test
-  @DisplayName("revokeToken [Failed-05 invalidClientId]")
+  @DisplayName("revokeToken [Failed-05 authUrl]")
   void revokeTokenFailed05(VertxTestContext testContext) {
+    JsonObject userJson = consumer.result();
+    
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId"))
+        .name(userJson.getString("firstName"), userJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonObject request = new JsonObject().put(RS_URL, DUMMY_AUTH_SERVER);
 
     mockHttpWebClient.setResponse("valid");
-    tokenService.revokeToken(mapToRevToken(revokeTokenInvalidClientId),
-        user("32a4b979-4f4a-4c44-b0c3-2fe109952b5f"),
+    tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
           testContext.completeNow();


### PR DESCRIPTION
API Body
--------
- Remove `clientId` and only keep `rsUrl`

Updated revoke endpoint based on IUDX RS implementation
----------------------------------
- Endpoint is `/admin/revokeToken`
- Pass special admin token (`sub` and `iss` is auth server URL) in `token` header
- Body is JSON with key `sub` having the user ID UUID
- Expect 200 OK and `type` to end with string 'success' in response

Changes
=======

openapi.yaml
============
- Removed clientId from request body

ApiServerVerticle
=================
- Removed check if requested clientId matches the user's clientId

RevokeToken
===========
- Remove clientId field and methods

TokenServiceImpl
================
- Add creation of special admin token and pass to TokenRevokeService

TokenRevokeService
==================
- Remove keycloak configuration and method to fetch token from keycloak
- Update token revoke endpoints and request body
- Add adminToken function param to httpRevokeRequest and httpPostAsync
- Add response validation to httpPostAsync
- Add stricter WebClientOptions

TokenVerticle
=============
- Remove keycloak configuration

Misc
====
- Added tests
- Update introspectToken to handle the admin token