### PR TITLE
Upgrade log4j2 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
-		<apache-log4j-core.version>2.15.0</apache-log4j-core.version>
+		<apache-log4j-core.version>2.16.0</apache-log4j-core.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
1) 2.16.0 upgrade,
  a) message lookups feature has been completely removed,
  b)  disables access to JNDI by default, so any attack vector related
to jndi is solved.
2) This solves CVE-2021-45046:
  Apache Log4j2 Thread Context Message Pattern
 and Context Lookup Pattern vulnerable to a denial of service attack.
3) Eventhough we don't use these in pattern layout in log4j2.xml, its
good to upgrade, as there maybe still undiscovered jndi attack vectors