### PR TITLE
Upgrade log4j2 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
-		<apache-log4j-core.version>2.16.0</apache-log4j-core.version>
+		<apache-log4j-core.version>2.17.0</apache-log4j-core.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
1) 2.17.0 upgrade
  a) Fix string substitution recursion and hence preventing DOS attack
  Refer: https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

2) This solves CVE-2021-45105
 Apache Log4j2 does not always protect from infinite recursion in lookup evaluation
 Refer : https://logging.apache.org/log4j/2.x/security.html

3) Eventhough we don't use these (context lookups) in pattern layout in log4j2.xml.
Its better we upgrade as there maybe still undiscovered attack vectors

PS: Due to large attention the log4shell got, many security researchers
are trying out to find flaws in log4j2 and we might see some more
upgrades in coming weeks fixing the security flaws, if any!!.