### PR TITLE
Upgrade log4j2 and  bug fix of  logging dependencies 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,9 @@
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
-		<apache-log4j-core.version>2.17.1</apache-log4j-core.version>
+		<apache-log4j-core.version>2.17.1</apache-log4j-core.version> 
+		<apache-log4j-api.version>2.17.1</apache-log4j-api.version>
+	        <apache-log4j-slf4j-impl.version>2.17.1</apache-log4j-slf4j-impl.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>
@@ -204,16 +206,16 @@
 			<artifactId>joda-time</artifactId>
 			<version>2.10.10</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
+	        <dependency>
+    			<groupId>org.apache.logging.log4j</groupId>
+    			<artifactId>log4j-slf4j-impl</artifactId>
+    			<version>${apache-log4j-slf4j-impl.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                        <version>${apache-log4j-api.version}</version>
+                </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
-		<apache-log4j-core.version>2.17.0</apache-log4j-core.version>
+		<apache-log4j-core.version>2.17.1</apache-log4j-core.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
 		<apache-log4j-core.version>2.17.1</apache-log4j-core.version> 
 		<apache-log4j-api.version>2.17.1</apache-log4j-api.version>
-	        <apache-log4j-slf4j-impl.version>2.17.1</apache-log4j-slf4j-impl.version>
+		<apache-log4j-slf4j-impl.version>2.17.1</apache-log4j-slf4j-impl.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<guava.version>30.1.1-jre</guava.version>
@@ -206,16 +206,16 @@
 			<artifactId>joda-time</artifactId>
 			<version>2.10.10</version>
 		</dependency>
-	        <dependency>
-    			<groupId>org.apache.logging.log4j</groupId>
-    			<artifactId>log4j-slf4j-impl</artifactId>
-    			<version>${apache-log4j-slf4j-impl.version}</version>
+		<dependency>
+   			<groupId>org.apache.logging.log4j</groupId>
+   			<artifactId>log4j-slf4j-impl</artifactId>
+   			<version>${apache-log4j-slf4j-impl.version}</version>
 		</dependency>
-                <dependency>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-api</artifactId>
-                        <version>${apache-log4j-api.version}</version>
-                </dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${apache-log4j-api.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
- This mitigates CVE-2021-44832
- CVE-2021-44832, is JNDI based RCE,
but its only effective if one uses jdbc appender (
which we don't) or an attacker can change the log4j2.xml file
to use jdbc appender. Hence a little difficult,
but possible. and so moderately rated.
- Hopefully, this will be the
"The Last JN(E)DI" Attack in log4j2 :)