### PR TITLE
Organize URNs into an enum

### DIFF
--- a/src/main/java/iudx/aaa/server/admin/AdminServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/admin/AdminServiceImpl.java
@@ -24,11 +24,7 @@ import static iudx.aaa.server.admin.Constants.SQL_UPDATE_ROLE_STATUS;
 import static iudx.aaa.server.admin.Constants.SUCC_TITLE_CREATED_ORG;
 import static iudx.aaa.server.admin.Constants.SUCC_TITLE_PROVIDER_REGS;
 import static iudx.aaa.server.admin.Constants.SUCC_TITLE_PROV_STATUS_UPDATE;
-import static iudx.aaa.server.admin.Constants.URN_ALREADY_EXISTS;
-import static iudx.aaa.server.admin.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.admin.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.admin.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.admin.Constants.URN_SUCCESS;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 
 import com.google.common.net.InternetDomainName;
 import io.vertx.core.AsyncResult;
@@ -313,7 +309,7 @@ public class AdminServiceImpl implements AdminService {
     Promise<JsonObject> promise = Promise.promise();
     policyService.createPolicy(request, user, promise);
     promise.future().onSuccess(res -> {
-      if (res.getString("type").equals(URN_SUCCESS)) {
+      if (res.getString("type").equals(URN_SUCCESS.toString())) {
         response.complete();
       } else {
         response.fail("Failed to set admin policy");

--- a/src/main/java/iudx/aaa/server/admin/Constants.java
+++ b/src/main/java/iudx/aaa/server/admin/Constants.java
@@ -23,13 +23,6 @@ public class Constants {
   public static final String KC_ADMIN_CLIENT_SEC = "keycloakAdminClientSecret";
   public static final String KC_ADMIN_POOLSIZE = "keycloakAdminPoolSize";
 
-  /* URNs */
-  public static final String URN_SUCCESS = "urn:dx:as:Success";
-  public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
-  public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
-  public static final String URN_INVALID_INPUT = "urn:dx:as:InvalidInput";
-  public static final String URN_ALREADY_EXISTS = "urn:dx:as:AlreadyExists";
-
   /* Response fields */
   public static final String RESP_USERID = "userId";
   public static final String RESP_STATUS = "status";

--- a/src/main/java/iudx/aaa/server/apiserver/Response.java
+++ b/src/main/java/iudx/aaa/server/apiserver/Response.java
@@ -2,6 +2,7 @@ package iudx.aaa.server.apiserver;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apiserver.util.Urn;
 
 /**
  * Response object to easily create a JSON response object. Objects must have <b>type</b>, and
@@ -116,6 +117,11 @@ public class Response {
 
     public ResponseBuilder type(String type) {
       this.type = type;
+      return this;
+    }
+    
+    public ResponseBuilder type(Urn type) {
+      this.type = type.toString();
       return this;
     }
 

--- a/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ClientAuthentication.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.apiserver.util;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.apiserver.util.Constants.CLIENT_ID;
 import static iudx.aaa.server.apiserver.util.Constants.CLIENT_SECRET;
 import static iudx.aaa.server.apiserver.util.Constants.ID;
@@ -9,13 +10,12 @@ import static iudx.aaa.server.apiserver.util.Constants.MISSING_TOKEN_CLIENT;
 import static iudx.aaa.server.apiserver.util.Constants.ROLES;
 import static iudx.aaa.server.apiserver.util.Constants.SQL_GET_KID_ROLES;
 import static iudx.aaa.server.apiserver.util.Constants.TOKEN_FAILED;
-import static iudx.aaa.server.apiserver.util.Constants.URN_MISSING_AUTH_TOKEN;
 import static iudx.aaa.server.apiserver.util.Constants.USER;
 import static iudx.aaa.server.token.Constants.INVALID_CLIENT_ID_SEC;
 import static iudx.aaa.server.token.Constants.LOG_DB_ERROR;
 import static iudx.aaa.server.token.Constants.LOG_UNAUTHORIZED;
 import static iudx.aaa.server.token.Constants.LOG_USER_SECRET;
-import static iudx.aaa.server.token.Constants.URN_INVALID_INPUT;
+
 import java.security.MessageDigest;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
@@ -3,6 +3,7 @@ package iudx.aaa.server.apiserver.util;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 
 public class Constants {
   // Header params
@@ -76,15 +77,6 @@ public class Constants {
 
   /* Query Params */
   public static final String QUERY_FILTER = "filter";
-
-  /* Response Messages */
-  public static final String URN_SUCCESS = "urn:dx:as:Success";
-  public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
-  public static final String URN_INVALID_INPUT = "urn:dx:as:InvalidInput";
-  public static final String URN_ALREADY_EXISTS = "urn:dx:as:AlreadyExists";
-  public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
-  public static final String URN_INVALID_AUTH_TOKEN = "urn:dx:as:InvalidAuthenticationToken";
-  public static final String URN_MISSING_AUTH_TOKEN = "urn:dx:as:MissingAuthenticationToken";
 
   public static final String TOKEN_FAILED = "Token authentication failed";
   public static final String MISSING_TOKEN = "Missing accessToken";

--- a/src/main/java/iudx/aaa/server/apiserver/util/FailureHandler.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/FailureHandler.java
@@ -1,13 +1,12 @@
 package iudx.aaa.server.apiserver.util;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.apiserver.util.Constants.ERR_TITLE_BAD_REQUEST;
 import static iudx.aaa.server.apiserver.util.Constants.HEADER_CONTENT_TYPE;
 import static iudx.aaa.server.apiserver.util.Constants.INVALID_JSON;
 import static iudx.aaa.server.apiserver.util.Constants.JSON_TIMEOUT;
 import static iudx.aaa.server.apiserver.util.Constants.MIME_APPLICATION_JSON;
 import static iudx.aaa.server.apiserver.util.Constants.STATUS;
-import static iudx.aaa.server.apiserver.util.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.apiserver.util.Constants.URN_MISSING_INFO;
 import java.time.format.DateTimeParseException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,9 +41,9 @@ public class FailureHandler implements Handler<RoutingContext> {
     Throwable failure = context.failure();
 
     if (failure instanceof DecodeException) {
-      processResponse(response, URN_INVALID_INPUT, INVALID_JSON);
+      processResponse(response, URN_INVALID_INPUT.toString(), INVALID_JSON);
     } else if (failure instanceof IllegalArgumentException) {
-      processResponse(response, URN_INVALID_INPUT, failure.getLocalizedMessage());
+      processResponse(response, URN_INVALID_INPUT.toString(), failure.getLocalizedMessage());
     } else if (failure instanceof NullPointerException) {
       response.setStatusCode(500).end();
       return;

--- a/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
@@ -1,6 +1,7 @@
 package iudx.aaa.server.apiserver.util;
 
 import static iudx.aaa.server.apiserver.util.Constants.*;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/iudx/aaa/server/apiserver/util/ProviderAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ProviderAuthentication.java
@@ -15,6 +15,7 @@ import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
 import iudx.aaa.server.apiserver.User;
 import static iudx.aaa.server.apiserver.util.Constants.*;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.token.Constants.LOG_DB_ERROR;
 
 public class ProviderAuthentication implements Handler<RoutingContext> {

--- a/src/main/java/iudx/aaa/server/apiserver/util/SearchUserHandler.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/SearchUserHandler.java
@@ -4,6 +4,7 @@ import static iudx.aaa.server.apiserver.util.Constants.CONTEXT_SEARCH_USER;
 import static iudx.aaa.server.apiserver.util.Constants.HEADER_EMAIL;
 import static iudx.aaa.server.apiserver.util.Constants.*;
 import static iudx.aaa.server.apiserver.util.Constants.HEADER_ROLE;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.vertx.core.Handler;

--- a/src/main/java/iudx/aaa/server/apiserver/util/Urn.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Urn.java
@@ -1,0 +1,23 @@
+package iudx.aaa.server.apiserver.util;
+
+public enum Urn {
+
+  URN_SUCCESS("urn:dx:as:Success"), 
+  URN_MISSING_INFO("urn:dx:as:MissingInformation"),
+  URN_INVALID_ROLE("urn:dx:as:InvalidRole"),
+  URN_INVALID_INPUT("urn:dx:as:InvalidInput"),
+  URN_ALREADY_EXISTS("urn:dx:as:AlreadyExists"),
+  URN_INVALID_AUTH_TOKEN("urn:dx:as:InvalidAuthenticationToken"),
+  URN_MISSING_AUTH_TOKEN("urn:dx:as:MissingAuthenticationToken");
+
+  private String text;
+
+  Urn(String text) {
+    this.text = text;
+  }
+
+  @Override
+  public String toString() {
+    return text;
+  }
+}

--- a/src/main/java/iudx/aaa/server/policy/CatalogueClient.java
+++ b/src/main/java/iudx/aaa/server/policy/CatalogueClient.java
@@ -61,7 +61,7 @@ import static iudx.aaa.server.policy.Constants.SERVER_NOT_PRESENT;
 import static iudx.aaa.server.policy.Constants.STATUS;
 import static iudx.aaa.server.policy.Constants.TYPE;
 import static iudx.aaa.server.policy.Constants.URL;
-import static iudx.aaa.server.policy.Constants.URN_CAT_SUCCESS;
+import static iudx.aaa.server.policy.Constants.CAT_SUCCESS_URN;
 import static iudx.aaa.server.policy.Constants.status;
 
 public class CatalogueClient {
@@ -476,7 +476,7 @@ public class CatalogueClient {
             obj -> {
               JsonObject res = obj.bodyAsJsonObject();
               if (obj.statusCode() == 200) {
-                if (res.getString(TYPE).equals(URN_CAT_SUCCESS))
+                if (res.getString(TYPE).equals(CAT_SUCCESS_URN))
                   p.complete(obj.bodyAsJsonObject().getJsonArray(RESULTS).getJsonObject(0));
               } else {
                 if (obj.statusCode() == 404) p.fail(ITEMNOTFOUND + id);

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -89,12 +89,8 @@ public class Constants {
       "Auth delegate may not create auth delegations";
   // URN
   public static final String ID_NOT_PRESENT = "id does not exist";
-  public static final String URN_SUCCESS = "urn:dx:as:Success";
-  public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
-  public static final String URN_INVALID_INPUT = "urn:dx:as:InvalidInput";
-  public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
-  public static final String URN_ALREADY_EXISTS = "urn:dx:as:AlreadyExists";
-  public static final String URN_CAT_SUCCESS = "urn:dx:cat:Success";
+  
+  public static final String CAT_SUCCESS_URN = "urn:dx:cat:Success";
   // future failure messages
   public static final String BAD_REQUEST = "bad request";
   public static final String SERVER_NOT_PRESENT = "servers not present:";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -46,6 +46,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.CAT_ID;
 import static iudx.aaa.server.policy.Constants.CHECK_ADMIN_POLICY;
 import static iudx.aaa.server.policy.Constants.CHECK_DELEGATOINS_VERIFY;
@@ -135,14 +136,9 @@ import static iudx.aaa.server.policy.Constants.UNAUTHORIZED_DELEGATE;
 import static iudx.aaa.server.policy.Constants.UPDATE_NOTIF_REQ_APPROVED;
 import static iudx.aaa.server.policy.Constants.UPDATE_NOTIF_REQ_REJECTED;
 import static iudx.aaa.server.policy.Constants.URL;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.policy.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.policy.Constants.URN_SUCCESS;
 import static iudx.aaa.server.policy.Constants.USERID;
 import static iudx.aaa.server.policy.Constants.USER_DETAILS;
 import static iudx.aaa.server.policy.Constants.USER_ID;
-import static iudx.aaa.server.policy.Constants.URN_ALREADY_EXISTS;
 import static iudx.aaa.server.policy.Constants.REQ_ID_ALREADY_NOT_EXISTS;
 import static iudx.aaa.server.policy.Constants.*;
 
@@ -431,7 +427,7 @@ public class PolicyServiceImpl implements PolicyService {
       Response r =
           new Response.ResponseBuilder()
               .type(URN_MISSING_INFO)
-              .title(URN_MISSING_INFO)
+              .title(URN_MISSING_INFO.toString())
               .detail(NO_USER)
               .status(401)
               .build();
@@ -631,7 +627,7 @@ public class PolicyServiceImpl implements PolicyService {
       Response r =
           new Response.ResponseBuilder()
               .type(URN_MISSING_INFO)
-              .title(URN_MISSING_INFO)
+              .title(URN_MISSING_INFO.toString())
               .detail(NO_USER)
               .status(404)
               .build();
@@ -1500,10 +1496,10 @@ public class PolicyServiceImpl implements PolicyService {
                     .onComplete(
                         resHandler -> {
                           if (resHandler.failed()) {
-                            String msg = URN_INVALID_INPUT;
+                            String msg = URN_INVALID_INPUT.toString();
                             int status = 400;
                             if (checkDuplicate.failed()) {
-                              msg = URN_ALREADY_EXISTS;
+                              msg = URN_ALREADY_EXISTS.toString();
                               status = 409;
                             }
                             
@@ -1999,7 +1995,7 @@ public class PolicyServiceImpl implements PolicyService {
 
                                                 if (createHandler.succeeded()) {
                                                   JsonObject result = createHandler.result();
-                                                  if (URN_SUCCESS.equalsIgnoreCase(
+                                                  if (URN_SUCCESS.toString().equalsIgnoreCase(
                                                       result.getString(TYPE))) {
 
                                                     Collector<Row, ?, List<Tuple>> policyCollector =

--- a/src/main/java/iudx/aaa/server/policy/createDelegate.java
+++ b/src/main/java/iudx/aaa/server/policy/createDelegate.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.BAD_REQUEST;
 import static iudx.aaa.server.policy.Constants.CHECK_AUTH_POLICY;
 import static iudx.aaa.server.policy.Constants.CHECK_AUTH_POLICY_DELEGATION;
@@ -44,9 +45,6 @@ import static iudx.aaa.server.policy.Constants.PROVIDER_NOT_REGISTERED;
 import static iudx.aaa.server.policy.Constants.SERVER_NOT_PRESENT;
 import static iudx.aaa.server.policy.Constants.UNAUTHORIZED;
 import static iudx.aaa.server.policy.Constants.URL;
-import static iudx.aaa.server.policy.Constants.URN_ALREADY_EXISTS;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_ROLE;
 import static iudx.aaa.server.policy.Constants.USER_ID;
 import static iudx.aaa.server.policy.Constants.roles;
 import static iudx.aaa.server.policy.Constants.status;

--- a/src/main/java/iudx/aaa/server/policy/createPolicy.java
+++ b/src/main/java/iudx/aaa/server/policy/createPolicy.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.*;
 
 public class createPolicy {

--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -41,13 +41,6 @@ public class Constants {
   public static final String RESP_PHONE = "phone";
   public static final String RESP_ORG = "organization";
 
-  /* URNs */
-  public static final String URN_SUCCESS = "urn:dx:as:Success";
-  public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
-  public static final String URN_INVALID_INPUT = "urn:dx:as:InvalidInput";
-  public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
-  public static final String URN_ALREADY_EXISTS = "urn:dx:as:AlreadyExists";
-
   /* Response title and details */
   public static final String SUCC_TITLE_CREATED_USER = "User profile has been created";
   public static final String PROVIDER_PENDING_MESG = ", Provider registration is pending approval";

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.CLIENT_SECRET_BYTES;
 import static iudx.aaa.server.registration.Constants.COMPOSE_FAILURE;
 import static iudx.aaa.server.registration.Constants.DEFAULT_CLIENT;
@@ -49,11 +50,6 @@ import static iudx.aaa.server.registration.Constants.SUCC_TITLE_ORG_READ;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_UPDATED_USER_ROLES;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_READ;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_FOUND;
-import static iudx.aaa.server.registration.Constants.URN_ALREADY_EXISTS;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.registration.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Constants.UUID_REGEX;
 
 import io.vertx.core.AsyncResult;

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -93,13 +93,6 @@ public class Constants {
   }
   
   /* Response Messages */
-  public static final String URN_SUCCESS = "urn:dx:as:Success";
-  public static final String URN_MISSING_INFO = "urn:dx:as:MissingInformation";
-  public static final String URN_INVALID_INPUT = "urn:dx:as:InvalidInput";
-  public static final String URN_ALREADY_EXISTS = "urn:dx:as:AlreadyExists";
-  public static final String URN_INVALID_ROLE = "urn:dx:as:InvalidRole";
-  public static final String URN_INVALID_AUTH_TOKEN = "urn:dx:as:InvalidAuthenticationToken";
-  
   public static final String REQ_RECEIVED = "Info: Request received";
   public static final String LOG_DB_ERROR = "Fail: Databse query; ";
   public static final String LOG_UNAUTHORIZED = "Fail: Unauthorized access; ";

--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -24,10 +24,11 @@ import iudx.aaa.server.apiserver.Response.ResponseBuilder;
 import iudx.aaa.server.policy.PolicyService;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.NIL_UUID;
-import static iudx.aaa.server.registration.Constants.URN_MISSING_INFO;
 import static iudx.aaa.server.token.Constants.*;
 
 /**

--- a/src/test/java/iudx/aaa/server/admin/CreateOrganizationTest.java
+++ b/src/test/java/iudx/aaa/server/admin/CreateOrganizationTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.admin;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_BULK_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_SERVERS;
@@ -175,7 +176,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 404);
-          assertEquals(Constants.URN_MISSING_INFO, response.getString("type"));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NO_USER_PROFILE, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NO_USER_PROFILE, response.getString("detail"));
           testContext.completeNow();
@@ -196,7 +197,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(Constants.URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -217,7 +218,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(Constants.URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -242,7 +243,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
-          assertEquals(response.getString("type"), Constants.URN_INVALID_INPUT);
+          assertEquals(response.getString("type"), URN_INVALID_INPUT.toString());
           assertEquals(response.getString("title"), Constants.ERR_TITLE_INVALID_DOMAIN);
           assertEquals(response.getString("detail"), Constants.ERR_DETAIL_INVALID_DOMAIN);
           protocolInUrl.flag();
@@ -253,7 +254,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
-          assertEquals(response.getString("type"), Constants.URN_INVALID_INPUT);
+          assertEquals(response.getString("type"), URN_INVALID_INPUT.toString());
           assertEquals(response.getString("title"), Constants.ERR_TITLE_INVALID_DOMAIN);
           assertEquals(response.getString("detail"), Constants.ERR_DETAIL_INVALID_DOMAIN);
           pathInUrl.flag();
@@ -264,7 +265,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
-          assertEquals(response.getString("type"), Constants.URN_INVALID_INPUT);
+          assertEquals(response.getString("type"), URN_INVALID_INPUT.toString());
           assertEquals(response.getString("title"), Constants.ERR_TITLE_INVALID_DOMAIN);
           assertEquals(response.getString("detail"), Constants.ERR_DETAIL_INVALID_DOMAIN);
           badDomain.flag();
@@ -275,7 +276,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 400);
-          assertEquals(response.getString("type"), Constants.URN_INVALID_INPUT);
+          assertEquals(response.getString("type"), URN_INVALID_INPUT.toString());
           assertEquals(response.getString("title"), Constants.ERR_TITLE_INVALID_DOMAIN);
           assertEquals(response.getString("detail"), Constants.ERR_DETAIL_INVALID_DOMAIN);
           specialChars.flag();
@@ -299,7 +300,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 201);
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_CREATED_ORG);
           JsonObject result = response.getJsonObject("results");
           assertEquals(result.getString("name"), name);
@@ -329,7 +330,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 201);
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_CREATED_ORG);
           JsonObject result = response.getJsonObject("results");
           assertEquals(result.getString("name"), name);
@@ -343,7 +344,7 @@ public class CreateOrganizationTest {
       adminService.createOrganization(request, user,
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(response.getInteger("status"), 409);
-            assertEquals(response.getString("type"), Constants.URN_ALREADY_EXISTS);
+            assertEquals(response.getString("type"), URN_ALREADY_EXISTS.toString());
             assertEquals(response.getString("title"), Constants.ERR_TITLE_DOMAIN_EXISTS);
             assertEquals(response.getString("detail"), Constants.ERR_DETAIL_DOMAIN_EXISTS);
             testContext.completeNow();
@@ -375,7 +376,7 @@ public class CreateOrganizationTest {
     adminService.createOrganization(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 201);
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_CREATED_ORG);
           JsonObject result = response.getJsonObject("results");
           assertEquals(result.getString("name"), name);
@@ -389,7 +390,7 @@ public class CreateOrganizationTest {
       adminService.createOrganization(requestSub, user,
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(response.getInteger("status"), 409);
-            assertEquals(response.getString("type"), Constants.URN_ALREADY_EXISTS);
+            assertEquals(response.getString("type"), URN_ALREADY_EXISTS.toString());
             assertEquals(response.getString("title"), Constants.ERR_TITLE_DOMAIN_EXISTS);
             assertEquals(response.getString("detail"), Constants.ERR_DETAIL_DOMAIN_EXISTS);
             testContext.completeNow();

--- a/src/test/java/iudx/aaa/server/admin/GetProviderRegistrationsTest.java
+++ b/src/test/java/iudx/aaa/server/admin/GetProviderRegistrationsTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.admin;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
@@ -199,7 +200,7 @@ public class GetProviderRegistrationsTest {
     adminService.getProviderRegistrations(RoleStatus.PENDING, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 404);
-          assertEquals(Constants.URN_MISSING_INFO, response.getString("type"));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NO_USER_PROFILE, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NO_USER_PROFILE, response.getString("detail"));
           testContext.completeNow();
@@ -220,7 +221,7 @@ public class GetProviderRegistrationsTest {
     adminService.getProviderRegistrations(RoleStatus.PENDING, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(Constants.URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -241,7 +242,7 @@ public class GetProviderRegistrationsTest {
     adminService.getProviderRegistrations(RoleStatus.PENDING, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(Constants.URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(Constants.ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(Constants.ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -277,7 +278,7 @@ public class GetProviderRegistrationsTest {
 
     adminService.getProviderRegistrations(RoleStatus.PENDING, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_PROVIDER_REGS);
           JsonArray res = response.getJsonArray("results");
           assertTrue(res.size() > 0);
@@ -320,7 +321,7 @@ public class GetProviderRegistrationsTest {
 
     adminService.getProviderRegistrations(RoleStatus.APPROVED, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_PROVIDER_REGS);
           JsonArray res = response.getJsonArray("results");
           assertTrue(res.size() > 0);
@@ -363,7 +364,7 @@ public class GetProviderRegistrationsTest {
 
     adminService.getProviderRegistrations(RoleStatus.REJECTED, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), Constants.URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), Constants.SUCC_TITLE_PROVIDER_REGS);
           JsonArray res = response.getJsonArray("results");
           assertTrue(res.size() > 0);

--- a/src/test/java/iudx/aaa/server/admin/UpdateProviderRegistrationStatusTest.java
+++ b/src/test/java/iudx/aaa/server/admin/UpdateProviderRegistrationStatusTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.admin;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.admin.Constants.CONFIG_AUTH_URL;
 import static iudx.aaa.server.admin.Constants.ERR_DETAIL_NOT_AUTH_ADMIN;
 import static iudx.aaa.server.admin.Constants.ERR_DETAIL_NO_USER_PROFILE;
@@ -9,10 +10,6 @@ import static iudx.aaa.server.admin.Constants.ERR_TITLE_NO_USER_PROFILE;
 import static iudx.aaa.server.admin.Constants.NIL_UUID;
 import static iudx.aaa.server.admin.Constants.RESP_STATUS;
 import static iudx.aaa.server.admin.Constants.SUCC_TITLE_PROV_STATUS_UPDATE;
-import static iudx.aaa.server.admin.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.admin.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.admin.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.admin.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
@@ -224,7 +221,7 @@ public class UpdateProviderRegistrationStatusTest {
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 404);
-          assertEquals(URN_MISSING_INFO, response.getString("type"));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
           assertEquals(ERR_TITLE_NO_USER_PROFILE, response.getString("title"));
           assertEquals(ERR_DETAIL_NO_USER_PROFILE, response.getString("detail"));
           testContext.completeNow();
@@ -249,7 +246,7 @@ public class UpdateProviderRegistrationStatusTest {
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -274,7 +271,7 @@ public class UpdateProviderRegistrationStatusTest {
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(response.getInteger("status"), 401);
-          assertEquals(URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           assertEquals(ERR_TITLE_NOT_AUTH_ADMIN, response.getString("title"));
           assertEquals(ERR_DETAIL_NOT_AUTH_ADMIN, response.getString("detail"));
           testContext.completeNow();
@@ -311,7 +308,7 @@ public class UpdateProviderRegistrationStatusTest {
     /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(2);
-      p.complete(new JsonObject().put("type", URN_SUCCESS));
+      p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
       return i.getMock();
     }).when(policyService).createPolicy(any(), any(), any());
 
@@ -326,7 +323,7 @@ public class UpdateProviderRegistrationStatusTest {
 
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), SUCC_TITLE_PROV_STATUS_UPDATE);
           JsonArray res = response.getJsonArray("results");
           assertTrue(res.size() > 0);
@@ -365,7 +362,7 @@ public class UpdateProviderRegistrationStatusTest {
     /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(2);
-      p.complete(new JsonObject().put("type", URN_SUCCESS));
+      p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
       return i.getMock();
     }).when(policyService).createPolicy(any(), any(), any());
 
@@ -380,7 +377,7 @@ public class UpdateProviderRegistrationStatusTest {
 
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), URN_INVALID_INPUT);
+          assertEquals(response.getString("type"), URN_INVALID_INPUT.toString());
           assertEquals(response.getString("title"), ERR_TITLE_INVALID_USER);
           assertEquals(response.getString("detail"), providerJson.getString("userId"));
           testContext.completeNow();
@@ -407,7 +404,7 @@ public class UpdateProviderRegistrationStatusTest {
     /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(2);
-      p.complete(new JsonObject().put("type", URN_SUCCESS));
+      p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
       return i.getMock();
     }).when(policyService).createPolicy(any(), any(), any());
 
@@ -425,7 +422,7 @@ public class UpdateProviderRegistrationStatusTest {
 
     adminService.updateProviderRegistrationStatus(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(response.getString("type"), URN_SUCCESS);
+          assertEquals(response.getString("type"), URN_SUCCESS.toString());
           assertEquals(response.getString("title"), SUCC_TITLE_PROV_STATUS_UPDATE);
           JsonArray res = response.getJsonArray("results");
           assertTrue(res.size() > 0);
@@ -444,7 +441,7 @@ public class UpdateProviderRegistrationStatusTest {
 
           adminService.updateProviderRegistrationStatus(request, user,
               testContext.succeeding(r -> testContext.verify(() -> {
-                assertEquals(r.getString("type"), URN_INVALID_INPUT);
+                assertEquals(r.getString("type"), URN_INVALID_INPUT.toString());
                 assertEquals(r.getString("title"), ERR_TITLE_INVALID_USER);
                 assertEquals(r.getString("detail"), providerJson.getString("userId"));
                 fail.flag();
@@ -502,7 +499,7 @@ public class UpdateProviderRegistrationStatusTest {
 
       adminService.updateProviderRegistrationStatus(newRequest, user,
           testContext.succeeding(r -> testContext.verify(() -> {
-            assertEquals(r.getString("type"), URN_SUCCESS);
+            assertEquals(r.getString("type"), URN_SUCCESS.toString());
             assertEquals(r.getString("title"), SUCC_TITLE_PROV_STATUS_UPDATE);
             JsonArray res = r.getJsonArray("results");
             assertTrue(res.size() > 0);

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static iudx.aaa.server.policy.Constants.URN_INVALID_ROLE;
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.TestRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -128,7 +128,7 @@ public class CreatePolicyTest {
                 testContext.verify(
                     () -> {
                       JsonObject result = response;
-                      assertEquals(URN_INVALID_ROLE, result.getString("type"));
+                      assertEquals(URN_INVALID_ROLE.toString(), result.getString("type"));
                       testContext.completeNow();
                     })));
   }

--- a/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
@@ -1,6 +1,7 @@
 
 package iudx.aaa.server.policy;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.AUTH_SERVER_URL;
 import static iudx.aaa.server.policy.Constants.ERR_DETAIL_DEL_DELEGATE_ROLES;
 import static iudx.aaa.server.policy.Constants.ERR_TITLE_AUTH_DELE_DELETE;
@@ -9,9 +10,6 @@ import static iudx.aaa.server.policy.Constants.ERR_TITLE_INVALID_ROLES;
 import static iudx.aaa.server.policy.Constants.NIL_UUID;
 import static iudx.aaa.server.policy.Constants.SUCC_TITLE_DELETE_DELE;
 import static iudx.aaa.server.policy.Constants.TYPE;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.policy.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_DELEG;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
@@ -252,7 +250,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, user, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           assertEquals(ERR_TITLE_INVALID_ID, response.getString("title"));
           assertEquals(randUuid, response.getString("detail"));
           testContext.completeNow();
@@ -280,7 +278,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, user, providerDetails,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           assertEquals(ERR_TITLE_AUTH_DELE_DELETE, response.getString("title"));
           assertEquals(authDelegId, response.getString("detail"));
           assertEquals(403, response.getInteger("status"));
@@ -319,7 +317,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, user, providerDetails,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           assertEquals(SUCC_TITLE_DELETE_DELE, response.getString("title"));
           assertEquals(200, response.getInteger("status"));
           deleted.flag();
@@ -329,7 +327,7 @@ public class DeleteDelegationTest {
     p.future().onSuccess(x -> {
       policyService.deleteDelegation(request, providerUser, new JsonObject(),
           testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
             assertEquals(ERR_TITLE_INVALID_ID, response.getString("title"));
             assertEquals(delegId, response.getString("detail"));
             assertEquals(400, response.getInteger("status"));
@@ -366,7 +364,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, userC, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString(TYPE));
           assertEquals(ERR_DETAIL_DEL_DELEGATE_ROLES, response.getString("detail"));
           assertEquals(ERR_TITLE_INVALID_ROLES, response.getString("title"));
           assertEquals(401, response.getInteger("status"));
@@ -375,7 +373,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, userD, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString(TYPE));
           assertEquals(ERR_DETAIL_DEL_DELEGATE_ROLES, response.getString("detail"));
           assertEquals(ERR_TITLE_INVALID_ROLES, response.getString("title"));
           assertEquals(401, response.getInteger("status"));
@@ -400,7 +398,7 @@ public class DeleteDelegationTest {
 
     policyService.deleteDelegation(request, providerUser, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           assertEquals(SUCC_TITLE_DELETE_DELE, response.getString("title"));
           assertEquals(200, response.getInteger("status"));
           testContext.completeNow();

--- a/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
@@ -1,14 +1,13 @@
 
 package iudx.aaa.server.policy;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.AUTH_SERVER_URL;
 import static iudx.aaa.server.policy.Constants.ERR_DETAIL_LIST_DELEGATE_ROLES;
 import static iudx.aaa.server.policy.Constants.ERR_TITLE_INVALID_ROLES;
 import static iudx.aaa.server.policy.Constants.NIL_UUID;
 import static iudx.aaa.server.policy.Constants.RESULTS;
 import static iudx.aaa.server.policy.Constants.TYPE;
-import static iudx.aaa.server.policy.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.policy.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_DELEG;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
@@ -252,7 +251,7 @@ public class ListDelegationTest {
 
     policyService.listDelegation(user, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonArray resp = response.getJsonArray(RESULTS);
           assertTrue(resp.size() == 2);
           resp.forEach(obj -> {
@@ -295,7 +294,7 @@ public class ListDelegationTest {
 
     policyService.listDelegation(user, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonArray resp = response.getJsonArray(RESULTS);
           assertTrue(resp.size() == 2);
           resp.forEach(obj -> {
@@ -340,7 +339,7 @@ public class ListDelegationTest {
 
     policyService.listDelegation(user, providerDetails,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonArray resp = response.getJsonArray(RESULTS);
           assertTrue(resp.size() == 1);
           resp.forEach(obj -> {
@@ -375,7 +374,7 @@ public class ListDelegationTest {
 
     policyService.listDelegation(user, new JsonObject(),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString(TYPE));
           assertEquals(ERR_DETAIL_LIST_DELEGATE_ROLES, response.getString("detail"));
           assertEquals(ERR_TITLE_INVALID_ROLES, response.getString("title"));
           assertEquals(401, response.getInteger("status"));

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -1,6 +1,7 @@
 
 package iudx.aaa.server.policy;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.*;
 import static iudx.aaa.server.policy.TestRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -120,7 +121,7 @@ public class ListPolicyTest {
         mockRegistrationFactory.setResponse("valid");
         policyService.listPolicy(validListPolicyProvider, new JsonObject(),
                 testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS, response.getString(TYPE));
+                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
                     testContext.completeNow();
                 })));
     }
@@ -133,7 +134,7 @@ public class ListPolicyTest {
         mockRegistrationFactory.setResponse("valid");
         policyService.listPolicy(validListPolicyConsumer, new JsonObject(),
                 testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS, response.getString(TYPE));
+                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
                     testContext.completeNow();
                 })));
     }
@@ -145,7 +146,7 @@ public class ListPolicyTest {
         mockRegistrationFactory.setResponse("valid");
         policyService.listPolicy(invalidListPolicy, new JsonObject(),
                 testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS, response.getString(TYPE));
+                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
                     testContext.completeNow();
                 })));
     }

--- a/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.CLIENT_SECRET_BYTES;
 import static iudx.aaa.server.registration.Constants.DEFAULT_CLIENT;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_ID_REQUIRED;
@@ -17,10 +18,6 @@ import static iudx.aaa.server.registration.Constants.RESP_CLIENT_ID;
 import static iudx.aaa.server.registration.Constants.RESP_CLIENT_NAME;
 import static iudx.aaa.server.registration.Constants.RESP_CLIENT_SC;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_CREATED_USER;
-import static iudx.aaa.server.registration.Constants.URN_ALREADY_EXISTS;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.registration.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_CONSUMERS;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
@@ -163,7 +160,7 @@ public class CreateUserTest {
           assertEquals(201, response.getInteger("status"));
           JsonObject result = response.getJsonObject("results");
 
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           assertEquals(SUCC_TITLE_CREATED_USER, response.getString("title"));
           assertTrue(
               result.getJsonArray("roles").getList().contains(Roles.CONSUMER.name().toLowerCase()));
@@ -206,7 +203,7 @@ public class CreateUserTest {
           assertEquals(201, response.getInteger("status"));
           JsonObject result = response.getJsonObject("results");
 
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           assertEquals(SUCC_TITLE_CREATED_USER + PROVIDER_PENDING_MESG,
               response.getString("title"));
           assertTrue(result.getJsonArray("roles").size() == 0);
@@ -250,7 +247,7 @@ public class CreateUserTest {
 
           JsonObject result = response.getJsonObject("results");
 
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           assertEquals(SUCC_TITLE_CREATED_USER, response.getString("title"));
           assertTrue(result.getJsonArray("roles").contains(Roles.DELEGATE.name().toLowerCase()));
           assertEquals(result.getString("email"), email);
@@ -294,7 +291,7 @@ public class CreateUserTest {
 
           JsonObject result = response.getJsonObject("results");
 
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           assertEquals(SUCC_TITLE_CREATED_USER + PROVIDER_PENDING_MESG,
               response.getString("title"));
           @SuppressWarnings("unchecked")
@@ -337,7 +334,7 @@ public class CreateUserTest {
 
     registrationService.createUser(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           assertEquals(400, response.getInteger("status"));
           assertEquals(ERR_DETAIL_ORG_NO_EXIST, response.getString("detail"));
           assertEquals(ERR_TITLE_ORG_NO_EXIST, response.getString("title"));
@@ -363,7 +360,7 @@ public class CreateUserTest {
 
     registrationService.createUser(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_MISSING_INFO, response.getString("type"));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
           assertEquals(400, response.getInteger("status"));
           assertEquals(ERR_DETAIL_ORG_ID_REQUIRED, response.getString("detail"));
           assertEquals(ERR_TITLE_ORG_ID_REQUIRED, response.getString("title"));
@@ -389,7 +386,7 @@ public class CreateUserTest {
     User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
     registrationService.createUser(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           assertEquals(400, response.getInteger("status"));
           assertEquals(ERR_DETAIL_ORG_NO_MATCH, response.getString("detail"));
           assertEquals(ERR_TITLE_ORG_NO_MATCH, response.getString("title"));
@@ -418,7 +415,7 @@ public class CreateUserTest {
     Promise<Void> completeReg = Promise.promise();
     registrationService.createUser(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           assertEquals(201, response.getInteger("status"));
           completeReg.complete();
         })));
@@ -427,7 +424,7 @@ public class CreateUserTest {
 
       registrationService.createUser(request, user,
           testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(URN_ALREADY_EXISTS, response.getString("type"));
+            assertEquals(URN_ALREADY_EXISTS.toString(), response.getString("type"));
             assertEquals(409, response.getInteger("status"));
             assertEquals(ERR_DETAIL_USER_EXISTS, response.getString("detail"));
             assertEquals(ERR_TITLE_USER_EXISTS, response.getString("title"));
@@ -454,7 +451,7 @@ public class CreateUserTest {
 
     registrationService.createUser(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           assertEquals(400, response.getInteger("status"));
           assertEquals(ERR_DETAIL_USER_NOT_KC, response.getString("detail"));
           assertEquals(ERR_TITLE_USER_NOT_KC, response.getString("title"));
@@ -488,7 +485,7 @@ public class CreateUserTest {
 
       registrationService.createUser(request, user,
           testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(URN_SUCCESS, response.getString("type"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
             assertEquals(201, response.getInteger("status"));
             testContext.completeNow();
           })));

--- a/src/test/java/iudx/aaa/server/registration/ListOrganizationTest.java
+++ b/src/test/java/iudx/aaa/server/registration/ListOrganizationTest.java
@@ -1,7 +1,7 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_ORG_READ;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -116,7 +116,7 @@ public class ListOrganizationTest {
     registrationService
         .listOrganization(testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(SUCC_TITLE_ORG_READ, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           @SuppressWarnings("unchecked")
           List<JsonObject> list = response.getJsonArray("results").getList();

--- a/src/test/java/iudx/aaa/server/registration/ListUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/ListUserTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_KC;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_NO_USER_PROFILE;
@@ -10,7 +11,6 @@ import static iudx.aaa.server.registration.Constants.RESP_EMAIL;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.RESP_PHONE;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_READ;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -235,7 +235,7 @@ public class ListUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_READ, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 
@@ -283,7 +283,7 @@ public class ListUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_READ, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 
@@ -330,7 +330,7 @@ public class ListUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_READ, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 

--- a/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_SEARCH_USR_INVALID_ROLE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_FOUND;
@@ -8,9 +9,6 @@ import static iudx.aaa.server.registration.Constants.ERR_TITLE_SEARCH_USR_INVALI
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_USER_NOT_FOUND;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_FOUND;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -200,7 +198,7 @@ public class SearchUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_FOUND, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 
@@ -241,7 +239,7 @@ public class SearchUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_FOUND, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 
@@ -293,7 +291,7 @@ public class SearchUserTest {
         testContext.succeeding(response -> testContext.verify(() -> {
           assertEquals(200, response.getInteger("status"));
           assertEquals(SUCC_TITLE_USER_FOUND, response.getString("title"));
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
           JsonObject result = response.getJsonObject("results");
 
@@ -329,7 +327,7 @@ public class SearchUserTest {
           assertEquals(401, response.getInteger("status"));
           assertEquals(ERR_TITLE_SEARCH_USR_INVALID_ROLE, response.getString("title"));
           assertEquals(ERR_DETAIL_SEARCH_USR_INVALID_ROLE, response.getString("detail"));
-          assertEquals(URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -355,7 +353,7 @@ public class SearchUserTest {
           assertEquals(401, response.getInteger("status"));
           assertEquals(ERR_TITLE_SEARCH_USR_INVALID_ROLE, response.getString("title"));
           assertEquals(ERR_DETAIL_SEARCH_USR_INVALID_ROLE, response.getString("detail"));
-          assertEquals(URN_INVALID_ROLE, response.getString("type"));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -381,7 +379,7 @@ public class SearchUserTest {
           assertEquals(404, response.getInteger("status"));
           assertEquals(ERR_TITLE_USER_NOT_FOUND, response.getString("title"));
           assertEquals(ERR_DETAIL_USER_NOT_FOUND, response.getString("detail"));
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -412,7 +410,7 @@ public class SearchUserTest {
           assertEquals(404, response.getInteger("status"));
           assertEquals(ERR_TITLE_USER_NOT_FOUND, response.getString("title"));
           assertEquals(ERR_DETAIL_USER_NOT_FOUND, response.getString("detail"));
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -444,7 +442,7 @@ public class SearchUserTest {
           assertEquals(404, response.getInteger("status"));
           assertEquals(ERR_TITLE_USER_NOT_FOUND, response.getString("title"));
           assertEquals(ERR_DETAIL_USER_NOT_FOUND, response.getString("detail"));
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }

--- a/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_NO_EXIST;
@@ -17,10 +18,6 @@ import static iudx.aaa.server.registration.Constants.RESP_EMAIL;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.RESP_PHONE;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_UPDATED_USER_ROLES;
-import static iudx.aaa.server.registration.Constants.URN_ALREADY_EXISTS;
-import static iudx.aaa.server.registration.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.registration.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.registration.Constants.URN_SUCCESS;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -197,7 +194,7 @@ public class UpdateUserTest {
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(400, response.getInteger("status"));
             assertEquals(ERR_TITLE_ORG_ID_REQUIRED, response.getString("title"));
-            assertEquals(URN_MISSING_INFO, response.getString("type"));
+            assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
             assertEquals(ERR_DETAIL_ORG_ID_REQUIRED, response.getString("detail"));
             testContext.completeNow();
           })));
@@ -232,7 +229,7 @@ public class UpdateUserTest {
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(400, response.getInteger("status"));
             assertEquals(ERR_TITLE_ORG_NO_EXIST, response.getString("title"));
-            assertEquals(URN_INVALID_INPUT, response.getString("type"));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
             assertEquals(ERR_DETAIL_ORG_NO_EXIST, response.getString("detail"));
             testContext.completeNow();
           })));
@@ -269,7 +266,7 @@ public class UpdateUserTest {
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(400, response.getInteger("status"));
             assertEquals(ERR_TITLE_ORG_NO_MATCH, response.getString("title"));
-            assertEquals(URN_INVALID_INPUT, response.getString("type"));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
             assertEquals(ERR_DETAIL_ORG_NO_MATCH, response.getString("detail"));
             testContext.completeNow();
           })));
@@ -307,7 +304,7 @@ public class UpdateUserTest {
           testContext.succeeding(response -> testContext.verify(() -> {
             assertEquals(200, response.getInteger("status"));
             assertEquals(SUCC_TITLE_UPDATED_USER_ROLES, response.getString("title"));
-            assertEquals(URN_SUCCESS, response.getString("type"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
             JsonObject result = response.getJsonObject("results");
 
@@ -374,7 +371,7 @@ public class UpdateUserTest {
             assertTrue(response.getString("detail").contains(ERR_DETAIL_ROLE_EXISTS));
             assertTrue(response.getString("detail").contains("delegate"));
             assertFalse(response.getString("detail").contains("provider"));
-            assertEquals(URN_ALREADY_EXISTS, response.getString("type"));
+            assertEquals(URN_ALREADY_EXISTS.toString(), response.getString("type"));
 
             testContext.completeNow();
           })));
@@ -420,7 +417,7 @@ public class UpdateUserTest {
 
             assertEquals(400, resp.getInteger("status"));
             assertEquals(ERR_TITLE_ORG_ID_REQUIRED, resp.getString("title"));
-            assertEquals(URN_MISSING_INFO, resp.getString("type"));
+            assertEquals(URN_MISSING_INFO.toString(), resp.getString("type"));
             assertEquals(ERR_DETAIL_ORG_ID_REQUIRED, resp.getString("detail"));
             noOrgIdFail.flag();
 
@@ -430,7 +427,7 @@ public class UpdateUserTest {
                 testContext.succeeding(response -> testContext.verify(() -> {
                   assertEquals(200, response.getInteger("status"));
                   assertEquals(SUCC_TITLE_UPDATED_USER_ROLES, response.getString("title"));
-                  assertEquals(URN_SUCCESS, response.getString("type"));
+                  assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
                   JsonObject result = response.getJsonObject("results");
 
@@ -504,7 +501,7 @@ public class UpdateUserTest {
             testContext.succeeding(response -> testContext.verify(() -> {
               assertEquals(200, response.getInteger("status"));
               assertEquals(SUCC_TITLE_UPDATED_USER_ROLES, response.getString("title"));
-              assertEquals(URN_SUCCESS, response.getString("type"));
+              assertEquals(URN_SUCCESS.toString(), response.getString("type"));
 
               JsonObject result = response.getJsonObject("results");
 

--- a/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
+++ b/src/test/java/iudx/aaa/server/token/TokenServiceTest.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.token;
 
+import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.token.Constants.ACCESS_TOKEN;
 import static iudx.aaa.server.token.Constants.AUD;
 import static iudx.aaa.server.token.Constants.CLAIM_ISSUER;
@@ -18,11 +19,6 @@ import static iudx.aaa.server.token.Constants.STATUS;
 import static iudx.aaa.server.token.Constants.SUB;
 import static iudx.aaa.server.token.Constants.TYPE;
 import static iudx.aaa.server.token.Constants.URL;
-import static iudx.aaa.server.token.Constants.URN_INVALID_AUTH_TOKEN;
-import static iudx.aaa.server.token.Constants.URN_INVALID_INPUT;
-import static iudx.aaa.server.token.Constants.URN_INVALID_ROLE;
-import static iudx.aaa.server.token.Constants.URN_MISSING_INFO;
-import static iudx.aaa.server.token.Constants.URN_SUCCESS;
 import static iudx.aaa.server.token.Constants.USER_ID;
 import static iudx.aaa.server.token.RequestPayload.expiredTipPayload;
 import static iudx.aaa.server.token.RequestPayload.mapToInspctToken;
@@ -282,7 +278,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid", RESOURCE_GROUP, DUMMY_SERVER);
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           JsonObject payload =
               getJwtPayload(response.getJsonObject("results").getString(ACCESS_TOKEN));
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
@@ -313,7 +309,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid", RESOURCE_ITEM, DUMMY_SERVER);
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           JsonObject payload =
               getJwtPayload(response.getJsonObject("results").getString(ACCESS_TOKEN));
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
@@ -343,7 +339,7 @@ public class TokenServiceTest {
 
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           JsonObject payload =
               getJwtPayload(response.getJsonObject("results").getString(ACCESS_TOKEN));
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
@@ -374,7 +370,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString("type"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
           JsonObject payload =
               getJwtPayload(response.getJsonObject("results").getString(ACCESS_TOKEN));
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
@@ -405,7 +401,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -431,7 +427,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString("type"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -454,7 +450,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("invalid");
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -475,7 +471,7 @@ public class TokenServiceTest {
 
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_MISSING_INFO, response.getString(TYPE));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -498,7 +494,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.createToken(request, user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -518,7 +514,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("valid");
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -538,7 +534,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("invalid");
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           assertEquals(400, response.getInteger(STATUS));
           testContext.completeNow();
         })));
@@ -561,7 +557,7 @@ public class TokenServiceTest {
     JsonObject request = new JsonObject().put(RS_URL, DUMMY_SERVER);
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_ROLE, response.getString(TYPE));
+          assertEquals(URN_INVALID_ROLE.toString(), response.getString(TYPE));
           assertEquals(400, response.getInteger(STATUS));
           testContext.completeNow();
         })));
@@ -583,7 +579,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("valid");
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_MISSING_INFO, response.getString(TYPE));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString(TYPE));
           assertEquals(404, response.getInteger(STATUS));
           testContext.completeNow();
         })));
@@ -604,7 +600,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("valid");
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -624,7 +620,7 @@ public class TokenServiceTest {
     mockHttpWebClient.setResponse("valid");
     tokenService.revokeToken(mapToRevToken(request), user,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -642,7 +638,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.validateToken(mapToInspctToken(token),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonObject payload = response.getJsonObject("results");
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
           assertEquals(payload.getString(SUB), consumer.result().getString("userId"));
@@ -668,7 +664,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("valid");
     tokenService.validateToken(mapToInspctToken(token),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonObject payload = response.getJsonObject("results");
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
           assertEquals(payload.getString(SUB), consumer.result().getString("userId"));
@@ -695,7 +691,7 @@ public class TokenServiceTest {
     mockPolicy.setResponse("invalid");
     tokenService.validateToken(mapToInspctToken(token),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_INPUT, response.getString(TYPE));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -715,7 +711,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(mapToInspctToken(invalidToken),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
+          assertEquals(URN_INVALID_AUTH_TOKEN.toString(), response.getString(TYPE));
           assertTrue(
               response.getJsonArray("results").getJsonObject(0).getString(STATUS).equals(DENY));
           testContext.completeNow();
@@ -728,7 +724,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(mapToInspctToken(expiredTipPayload),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
+          assertEquals(URN_INVALID_AUTH_TOKEN.toString(), response.getString(TYPE));
           assertTrue(
               response.getJsonArray("results").getJsonObject(0).getString(STATUS).equals(DENY));
           testContext.completeNow();
@@ -743,7 +739,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(introspect,
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_MISSING_INFO, response.getString("type"));
+          assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
           testContext.completeNow();
         })));
   }
@@ -754,7 +750,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(mapToInspctToken(randomToken),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
+          assertEquals(URN_INVALID_AUTH_TOKEN.toString(), response.getString(TYPE));
           assertTrue(
               response.getJsonArray("results").getJsonObject(0).getString(STATUS).equals(DENY));
           testContext.completeNow();
@@ -774,7 +770,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(mapToInspctToken(token),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_INVALID_AUTH_TOKEN, response.getString(TYPE));
+          assertEquals(URN_INVALID_AUTH_TOKEN.toString(), response.getString(TYPE));
           testContext.completeNow();
         })));
   }
@@ -790,7 +786,7 @@ public class TokenServiceTest {
 
     tokenService.validateToken(mapToInspctToken(token),
         testContext.succeeding(response -> testContext.verify(() -> {
-          assertEquals(URN_SUCCESS, response.getString(TYPE));
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
           JsonObject payload = response.getJsonObject("results");
           assertEquals(payload.getString(ISS), DUMMY_AUTH_SERVER);
           assertEquals(payload.getString(SUB), DUMMY_AUTH_SERVER);


### PR DESCRIPTION
apiserver/util/Urn
--------------------
- created Urn enum
- override toString to get actual URN message string

src/main/*
----------
- remove Urns from each service Constants file
- import Urn to all files where required
- in some places where the URN string is needed, use toString()

apiserver/Response
------------------
- add method to ResponseBuilder to create set `type` for a response using the Urn enum

policy/CatalogueClient, policy/Constants
----------------------------------------
- change Catalogue URN constant name from `URN_CAT_SUCCESS` to `CAT_SUCCESS_URN` to differentiate it

src/test/*
----------
- import Urn to all files where required
- use toString function when performing assertEquals of `type` in response