### PR TITLE
[DRAFT] Client secret regen

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1261,7 +1261,6 @@ paths:
           application/json:
             schema:
               description: ''
-              type: object
               x-examples:
                 example-1:
                   roles:
@@ -1269,27 +1268,38 @@ paths:
                     - consumer
                     - delegate
                   orgId: 123e4567-e89b-12d3-a456-426614174000
-              properties:
-                roles:
-                  type: array
-                  minItems: 1
-                  uniqueItems: true
-                  maxItems: 2
-                  items:
-                    type: string
-                    enum:
-                      - consumer
-                      - delegate
-                    minLength: 5
-                    maxLength: 10
-                orgId:
-                  type: string
-                  format: uuid
-                  minLength: 36
-                  maxLength: 36
-                  pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
-              required:
-                - roles
+              oneOf:
+                - properties:
+                    roles:
+                      type: array
+                      minItems: 1
+                      uniqueItems: true
+                      maxItems: 2
+                      items:
+                        type: string
+                        enum:
+                          - consumer
+                          - delegate
+                        minLength: 5
+                        maxLength: 10
+                    orgId:
+                      type: string
+                      format: uuid
+                      minLength: 36
+                      maxLength: 36
+                      pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
+                  required:
+                    - roles
+                - properties:
+                    clientId:
+                      type: string
+                      pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
+                      minLength: 36
+                      maxLength: 36
+                      format: uuid
+                  required:
+                    - clientId
+              type: object
             examples:
               Update UserProfile:
                 value:
@@ -3748,3 +3758,4 @@ components:
       scheme: bearer
       description: ''
   responses: {}
+

--- a/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
+++ b/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
@@ -18,6 +18,7 @@ public class UpdateProfileRequest {
 
   UUID orgId = UUID.fromString(Constants.NIL_UUID);
   List<Roles> roles = new ArrayList<Roles>();
+  UUID clientId = UUID.fromString(Constants.NIL_UUID);
 
   public List<Roles> getRoles() {
     return roles;
@@ -37,6 +38,14 @@ public class UpdateProfileRequest {
     return obj;
   }
 
+  public String getClientId() {
+    return this.clientId.toString();
+  }
+
+  public void setClientId(String orgId) {
+    this.clientId = UUID.fromString(orgId);
+  }
+
   public String getOrgId() {
     return this.orgId.toString();
   }
@@ -46,6 +55,10 @@ public class UpdateProfileRequest {
   }
 
   private static JsonObject rolesToUpperCase(JsonObject json) {
+    if(!json.containsKey("roles")) {
+      return json;
+    }
+    
     JsonArray roles = json.getJsonArray("roles");
     json.remove("roles");
     json.put("roles",

--- a/src/main/java/iudx/aaa/server/registration/ComposeException.java
+++ b/src/main/java/iudx/aaa/server/registration/ComposeException.java
@@ -1,0 +1,31 @@
+package iudx.aaa.server.registration;
+
+import iudx.aaa.server.apiserver.Response;
+import iudx.aaa.server.apiserver.Response.ResponseBuilder;
+
+public class ComposeException extends Exception {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  private final Response response;
+
+  public ComposeException(Response response) {
+    super(response.getTitle());
+    this.response = response;
+  }
+
+  public ComposeException(int status, String type, String title, String detail) {
+    super(title);
+    this.response =
+        new ResponseBuilder().status(status).type(type).title(title).detail(detail).build();
+  }
+
+  public Response getResponse() {
+    return response;
+  }
+
+
+}

--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -1,5 +1,8 @@
 package iudx.aaa.server.registration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Constants for Registration service for SQL queries, URNs, responses and other values.
  */
@@ -29,6 +32,11 @@ public class Constants {
   public static final String KC_ADMIN_CLIENT_ID = "keycloakAdminClientId";
   public static final String KC_ADMIN_CLIENT_SEC = "keycloakAdminClientSecret";
   public static final String KC_ADMIN_POOLSIZE = "keycloakAdminPoolSize";
+  public static final String CONFIG_AUTH_URL = "authServerDomain";
+  
+  /* Set during RegistrationVerticle start() method */
+  public static String AUTH_SERVER_URL = "";
+  public static List<String> SERVERS_OMITTED_FROM_TOKEN_REVOKE = new ArrayList<String>();
   
   public static final int CLIENT_SECRET_BYTES = 20; 
 
@@ -55,6 +63,7 @@ public class Constants {
   public static final String SUCC_TITLE_USER_FOUND = "User found";
   public static final String SUCC_TITLE_ORG_READ = "Organizations";
   public static final String SUCC_TITLE_UPDATED_USER_ROLES = "Registered for requested roles";
+  public static final String SUCC_TITLE_REGEN_CLIENT_SECRET = "Regenerated client secret for requested client ID";
 
   public static final String ERR_TITLE_ROLE_EXISTS = "Already registered for requested role";
   public static final String ERR_DETAIL_ROLE_EXISTS = "You have already registered as ";
@@ -88,6 +97,9 @@ public class Constants {
       "User does not have required role to search for user";
   public static final String ERR_DETAIL_SEARCH_USR_INVALID_ROLE =
       "Must have provider/admin roles or be an auth delegate";
+  
+  public static final String ERR_TITLE_INVALID_CLI_ID = "Invalid client ID";
+  public static final String ERR_DETAIL_INVALID_CLI_ID = "Requested client ID not found";
 
   /* SQL queries */
   public static final String SQL_FIND_USER_BY_KC_ID =
@@ -140,4 +152,14 @@ public class Constants {
           + "roles ON users.id = roles.user_id "
           + "WHERE users.keycloak_id = $1::uuid AND roles.role = $2::"
           + "role_enum AND roles.status = 'APPROVED'";
+  
+  public static final String SQL_CHECK_CLIENT_ID_EXISTS =
+      "SELECT EXISTS (SELECT 1 FROM user_clients WHERE client_id = $1::uuid AND user_id = $2::uuid)";
+  
+  public static final String SQL_GET_SERVERS_FOR_REVOKE =
+      "SELECT url FROM resource_server WHERE url != ALL($1::text[])";
+  
+  public static final String SQL_UPDATE_CLIENT_SECRET =
+      "UPDATE user_clients SET client_secret = $1::text, updated_at = NOW() "
+          + "WHERE client_id = $2::uuid AND user_id = $3::uuid";
 }


### PR DESCRIPTION
- Draft PR, some things to decide before proceeding

# Changes
- Added `resetClientSecret` method to regenerate client secret for a given client ID
- Update `UpdateProfile` request object to accept client ID
- Updated OpenAPI spec
- Separate the adding roles code into separate function `addRoles`
- Created custom exception `ComposeException`
- Using the exception to send failures from `resetClientSecret` and `addRoles` back to the update service easily


## Omitting servers from token revoke
- Before the client secret is regenerated, all servers must be notified to revoke tokens of said user
- Currently we ignore if token revoke to a server fails for some or other reason, and we go ahead with regen
- In case this assumption changes, we have an array containing server URLs which are omitted from the token revoke
- The array will be maintained in the config
- Is this a valid 'feature'/assumption to keep?

## Custom exception between service and methods in the service
- Between service and API server, the future success/failure assumption is:
  - All expected successes and failures in the service translate to a succeeded future in the API server with JSON response
  - Only internal errors/unexpected failures translate to failed futures in the API server
- This is straightforward because once the service completes, the API server only completes the request with whatever the service sends

- When the service calls a function w/ a promise, the failure/success of said function needs to be handled by the service
  - w.r.t. to Registration, Admin services, this did not show up much, until now
  - the Policy service had this scenario frequently and used a switch case to handle different failures from methods by checking the String message of the failure
- Also, if the service uses a compose chain, the chain must be handled in case of a failure before passing to the API server
   - This was being handled by first sending a succeeded future to the handler to the API server with the JSON response and then returning a failed future with a static message. The failed future was caught at the end of the compose chain and then checked if it was a 'compose failure' or an internal error

Instead of this, in some cases we can possibly use a custom exception (containing the response to be sent). 
 - For the first case, the function can send a failed future with the custom exception, which again directly gets handled at the service compose chain.
- For the second case, since a compose chain is most of the time being used in a service, the failure can be handled at the end of said compose chain.
- In case the function itself has a compose chain, it behaves like the second case
