### PR TITLE
Client secret regeneration feature in PUT /user/profile

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -61,7 +61,8 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "keycloakOptions"],
+      "required":["postgresOptions", "keycloakOptions", "commonOptions"],
+      "serversOmittedFromRevoke":[],
       "poolSize": "25"
     },
     {

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -61,7 +61,8 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "keycloakOptions"],
+      "required":["postgresOptions", "keycloakOptions", "commonOptions"],
+      "serversOmittedFromRevoke":[],
       "poolSize": "25"
     },
     {

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -61,7 +61,8 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "keycloakOptions"],
+      "required":["postgresOptions", "keycloakOptions", "commonOptions"],
+      "serversOmittedFromRevoke":[],
       "poolSize": "5"
     },
     {

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -61,7 +61,8 @@
     {
       "id": "iudx.aaa.server.registration.RegistrationVerticle",
       "verticleInstances": 1,
-      "required":["postgresOptions", "keycloakOptions"],
+      "required":["postgresOptions", "keycloakOptions", "commonOptions"],
+      "serversOmittedFromRevoke":[],
       "poolSize": "25"
     },
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1261,7 +1261,6 @@ paths:
           application/json:
             schema:
               description: ''
-              type: object
               x-examples:
                 example-1:
                   roles:
@@ -1269,27 +1268,38 @@ paths:
                     - consumer
                     - delegate
                   orgId: 123e4567-e89b-12d3-a456-426614174000
-              properties:
-                roles:
-                  type: array
-                  minItems: 1
-                  uniqueItems: true
-                  maxItems: 2
-                  items:
-                    type: string
-                    enum:
-                      - consumer
-                      - delegate
-                    minLength: 5
-                    maxLength: 10
-                orgId:
-                  type: string
-                  format: uuid
-                  minLength: 36
-                  maxLength: 36
-                  pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
-              required:
-                - roles
+              oneOf:
+                - properties:
+                    roles:
+                      type: array
+                      minItems: 1
+                      uniqueItems: true
+                      maxItems: 2
+                      items:
+                        type: string
+                        enum:
+                          - consumer
+                          - delegate
+                        minLength: 5
+                        maxLength: 10
+                    orgId:
+                      type: string
+                      format: uuid
+                      minLength: 36
+                      maxLength: 36
+                      pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
+                  required:
+                    - roles
+                - properties:
+                    clientId:
+                      type: string
+                      pattern: '^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$'
+                      minLength: 36
+                      maxLength: 36
+                      format: uuid
+                  required:
+                    - clientId
+              type: object
             examples:
               Update UserProfile:
                 value:
@@ -3748,3 +3758,4 @@ components:
       scheme: bearer
       description: ''
   responses: {}
+

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1064,11 +1064,11 @@ paths:
       security:
         - authorization: []
     put:
-      summary: 'Update User Profile [Role]'
+      summary: 'Update User Profile - Add roles, regenerate client secret'
       operationId: put-auth-v1-user-profile
       responses:
         '200':
-          description: Successfully updated the user roles.
+          description: Successfully updated the user profile.
           content:
             application/json:
               schema:
@@ -1147,6 +1147,8 @@ paths:
                             clientId:
                               type: string
                               minLength: 1
+                            clientSecret:
+                              type: string
                           required:
                             - clientName
                             - clientId
@@ -1173,7 +1175,7 @@ paths:
                   - title
                   - results
               examples:
-                Updated User Profile:
+                Added roles successfully:
                   value:
                     type: 'urn:dx:as:Success'
                     title: Registered for requested roles
@@ -1188,7 +1190,29 @@ paths:
                       userId: 67194fc9-495e-40f7-b016-4470c1d4397f
                       clients:
                         - clientName: default
-                          clientId: 6d0b58c3-c0c4-48af-bca2-4f255c0e73a7
+                          clientId: 25b2c2d5-a7fc-47d0-89e4-8709a1560bfa
+                      email: ngoaf@chspomvjuq.com
+                      phone: '9989967899'
+                      organization:
+                        name: example
+                        url: example.com
+                Regenerated client secret successfully:
+                  value:
+                    type: 'urn:dx:as:Success'
+                    title: Regenerated client secret for requested client ID
+                    results:
+                      keycloakId: c0c52fd1-e9de-456c-b553-8d408e8d2a42
+                      name:
+                        firstName: Foo
+                        lastName: Bar
+                      roles:
+                        - consumer
+                        - delegate
+                      userId: 67194fc9-495e-40f7-b016-4470c1d4397f
+                      clients:
+                        - clientName: default
+                          clientId: 25b2c2d5-a7fc-47d0-89e4-8709a1560bfa
+                          clientSecret: cf2f0e52df08ec08d7eb1706f7c63696a41de41e
                       email: ngoaf@chspomvjuq.com
                       phone: '9989967899'
                       organization:
@@ -1229,23 +1253,39 @@ paths:
                     title: Token authentication failed
                     detail: Inactive Token
         '404':
-          description: A user profile for the user does not exist.
+          description: |-
+            - A user profile for the user does not exist.
+            - The client ID does not exist
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                Example:
+                User profile does not exist:
                   value:
                     type: 'urn:dx:as:MissingInformation'
                     title: User profile does not exist
                     detail: Please register to create user profile
+                Client ID does not exist:
+                  value:
+                    type: 'urn:dx:as:InvalidInput'
+                    title: Invalid client ID
+                    detail: Requested client ID not found
       description: |-
         Update an existing user profile. Currently a user may use this API to:
         - Add roles to their user profile
+        - Regenerate a client secret corresponding to a client ID (and as a result, revoking all tokens issued in the user's name)
+
+        **NOTE: The operations cannot be done simultaneously.**
 
         ## Add roles
-        A user may add `consumer` and `delegate` roles to their user profile. **The `provider` role cannot be added**.
+        A user may add `consumer` and `delegate` roles to their user profile. **The `provider` role cannot be added**. 
+
+        ## Regenerate client secret
+        A user may regenerate a client secret corresponding to a client ID in case they have lost the client secret or it has been compromised. A new client secret will be generated and sent as part of the output **and will not be shown again.** 
+
+        ### Token revocation before regeneration
+        In addition to regenerating the client secret, **the AAA server notifies all servers recognized by IUDX to revoke all tokens issued in the user's name (with the user's credentials) before the regeneration request was made**. The AAA server is effectively calling the `POST /auth/v1/token/revoke` API for all servers on behalf of the user. This is done to account for the scenario where the client secret has been compromised and tokens have been issued by a malicious user. 
       parameters:
         - schema:
             type: string
@@ -1297,19 +1337,24 @@ paths:
                       minLength: 36
                       maxLength: 36
                       format: uuid
+                      description: A valid client ID belonging to the user
                   required:
                     - clientId
               type: object
             examples:
-              Update UserProfile:
+              Add roles:
                 value:
                   roles:
                     - consumer
                     - delegate
                   orgId: 123e4567-e89b-12d3-a456-426614174000
+              Regenerate client secret:
+                value:
+                  clientId: 25b2c2d5-a7fc-47d0-89e4-8709a1560bfa
         description: |-
           - `orgId` is a valid organization ID obtain from the `GET /auth/v1/organizations` API
           - **`orgId` is required for `delegate` roles**
+          - `clientId` is a valid client ID (belonging to the user) whose corresponding client secret needs to be generate
         required: true
       tags:
         - User APIs
@@ -3758,4 +3803,3 @@ components:
       scheme: bearer
       description: ''
   responses: {}
-

--- a/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
+++ b/src/main/java/iudx/aaa/server/apiserver/UpdateProfileRequest.java
@@ -18,6 +18,7 @@ public class UpdateProfileRequest {
 
   UUID orgId = UUID.fromString(Constants.NIL_UUID);
   List<Roles> roles = new ArrayList<Roles>();
+  UUID clientId = UUID.fromString(Constants.NIL_UUID);
 
   public List<Roles> getRoles() {
     return roles;
@@ -37,6 +38,14 @@ public class UpdateProfileRequest {
     return obj;
   }
 
+  public String getClientId() {
+    return this.clientId.toString();
+  }
+
+  public void setClientId(String orgId) {
+    this.clientId = UUID.fromString(orgId);
+  }
+
   public String getOrgId() {
     return this.orgId.toString();
   }
@@ -46,6 +55,10 @@ public class UpdateProfileRequest {
   }
 
   private static JsonObject rolesToUpperCase(JsonObject json) {
+    if(!json.containsKey("roles")) {
+      return json;
+    }
+    
     JsonArray roles = json.getJsonArray("roles");
     json.remove("roles");
     json.put("roles",

--- a/src/main/java/iudx/aaa/server/registration/ComposeException.java
+++ b/src/main/java/iudx/aaa/server/registration/ComposeException.java
@@ -1,0 +1,51 @@
+package iudx.aaa.server.registration;
+
+import iudx.aaa.server.apiserver.Response;
+import iudx.aaa.server.apiserver.Response.ResponseBuilder;
+
+/**
+ * ComposeException can be used when failing futures in services or methods called by services.
+ * Since Vert.x allows to fail a future using a Throwable instead of a string, this allows the
+ * Throwable to be caught and handled at the end of a compose chain in an onFailure() block The
+ * exception uses the {@link iudx.aaa.server.apiserver.Response} object, which allows the error
+ * response to be created and passed on in the event of the particular failure. The Response can
+ * then be sent back to the API server when the exception is caught and handled.
+ */
+public class ComposeException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Response response;
+
+  /**
+   * Create a new ComposeException using a Response object (preferably representing an error). The
+   * title field of the Response object is used as the message for the Exception.
+   * 
+   * @param response The Response object
+   */
+  public ComposeException(Response response) {
+    super(response.getTitle());
+    this.response = response;
+  }
+
+  /**
+   * Create a new ComposeException with the parameters needed to create an Response object
+   * representing an error. The title field is used as the Exception message.
+   * 
+   * @param status The HTTP status code
+   * @param type The appropriate URN
+   * @param title The appropriate title
+   * @param detail The appropriate reason for the error
+   */
+  public ComposeException(int status, String type, String title, String detail) {
+    super(title);
+    this.response =
+        new ResponseBuilder().status(status).type(type).title(title).detail(detail).build();
+  }
+
+  public Response getResponse() {
+    return response;
+  }
+
+
+}

--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -29,6 +29,8 @@ public class Constants {
   public static final String KC_ADMIN_CLIENT_ID = "keycloakAdminClientId";
   public static final String KC_ADMIN_CLIENT_SEC = "keycloakAdminClientSecret";
   public static final String KC_ADMIN_POOLSIZE = "keycloakAdminPoolSize";
+  public static final String CONFIG_AUTH_URL = "authServerDomain";
+  public static final String CONFIG_OMITTED_SERVERS = "serversOmittedFromRevoke";
   
   public static final int CLIENT_SECRET_BYTES = 20; 
 
@@ -48,6 +50,7 @@ public class Constants {
   public static final String SUCC_TITLE_USER_FOUND = "User found";
   public static final String SUCC_TITLE_ORG_READ = "Organizations";
   public static final String SUCC_TITLE_UPDATED_USER_ROLES = "Registered for requested roles";
+  public static final String SUCC_TITLE_REGEN_CLIENT_SECRET = "Regenerated client secret for requested client ID";
 
   public static final String ERR_TITLE_ROLE_EXISTS = "Already registered for requested role";
   public static final String ERR_DETAIL_ROLE_EXISTS = "You have already registered as ";
@@ -81,6 +84,9 @@ public class Constants {
       "User does not have required role to search for user";
   public static final String ERR_DETAIL_SEARCH_USR_INVALID_ROLE =
       "Must have provider/admin roles or be an auth delegate";
+  
+  public static final String ERR_TITLE_INVALID_CLI_ID = "Invalid client ID";
+  public static final String ERR_DETAIL_INVALID_CLI_ID = "Requested client ID not found";
 
   /* SQL queries */
   public static final String SQL_FIND_USER_BY_KC_ID =
@@ -133,4 +139,14 @@ public class Constants {
           + "roles ON users.id = roles.user_id "
           + "WHERE users.keycloak_id = $1::uuid AND roles.role = $2::"
           + "role_enum AND roles.status = 'APPROVED'";
+  
+  public static final String SQL_CHECK_CLIENT_ID_EXISTS =
+      "SELECT EXISTS (SELECT 1 FROM user_clients WHERE client_id = $1::uuid AND user_id = $2::uuid)";
+  
+  public static final String SQL_GET_SERVERS_FOR_REVOKE =
+      "SELECT url FROM resource_server WHERE url != ALL($1::text[])";
+  
+  public static final String SQL_UPDATE_CLIENT_SECRET =
+      "UPDATE user_clients SET client_secret = $1::text, updated_at = NOW() "
+          + "WHERE client_id = $2::uuid AND user_id = $3::uuid";
 }

--- a/src/main/java/iudx/aaa/server/registration/RegistrationService.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationService.java
@@ -75,7 +75,8 @@ public interface RegistrationService {
       JsonObject authDelegateDetails, Handler<AsyncResult<JsonObject>> handler);
 
   /**
-   * The updateUser implements the user update operation. Currently role addition is allowed.
+   * The updateUser implements the user update operation. Currently role addition and client secret
+   * regeneration is allowed.
    * 
    * @param request the request body in the form of UpdateProfileRequest data object
    * @param handler the request handler which returns a JsonObject

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -3,7 +3,10 @@ package iudx.aaa.server.registration;
 import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.registration.Constants.CLIENT_SECRET_BYTES;
 import static iudx.aaa.server.registration.Constants.COMPOSE_FAILURE;
+import static iudx.aaa.server.registration.Constants.CONFIG_AUTH_URL;
+import static iudx.aaa.server.registration.Constants.CONFIG_OMITTED_SERVERS;
 import static iudx.aaa.server.registration.Constants.DEFAULT_CLIENT;
+import static iudx.aaa.server.registration.Constants.ERR_DETAIL_INVALID_CLI_ID;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_NO_EXIST;
@@ -13,6 +16,7 @@ import static iudx.aaa.server.registration.Constants.ERR_DETAIL_SEARCH_USR_INVAL
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_EXISTS;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_FOUND;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_KC;
+import static iudx.aaa.server.registration.Constants.ERR_TITLE_INVALID_CLI_ID;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ORG_NO_EXIST;
@@ -33,6 +37,7 @@ import static iudx.aaa.server.registration.Constants.RESP_CLIENT_SC;
 import static iudx.aaa.server.registration.Constants.RESP_EMAIL;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.RESP_PHONE;
+import static iudx.aaa.server.registration.Constants.SQL_CHECK_CLIENT_ID_EXISTS;
 import static iudx.aaa.server.registration.Constants.SQL_CREATE_CLIENT;
 import static iudx.aaa.server.registration.Constants.SQL_CREATE_ROLE;
 import static iudx.aaa.server.registration.Constants.SQL_CREATE_USER;
@@ -43,13 +48,16 @@ import static iudx.aaa.server.registration.Constants.SQL_GET_CLIENTS_FORMATTED;
 import static iudx.aaa.server.registration.Constants.SQL_GET_KC_ID_FROM_ARR;
 import static iudx.aaa.server.registration.Constants.SQL_GET_ORG_DETAILS;
 import static iudx.aaa.server.registration.Constants.SQL_GET_PHONE_JOIN_ORG;
+import static iudx.aaa.server.registration.Constants.SQL_GET_SERVERS_FOR_REVOKE;
 import static iudx.aaa.server.registration.Constants.SQL_GET_UID_ORG_ID_CHECK_ROLE;
+import static iudx.aaa.server.registration.Constants.SQL_UPDATE_CLIENT_SECRET;
 import static iudx.aaa.server.registration.Constants.SQL_UPDATE_ORG_ID;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_CREATED_USER;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_ORG_READ;
+import static iudx.aaa.server.registration.Constants.SUCC_TITLE_REGEN_CLIENT_SECRET;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_UPDATED_USER_ROLES;
-import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_READ;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_FOUND;
+import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_READ;
 import static iudx.aaa.server.registration.Constants.UUID_REGEX;
 
 import io.vertx.core.AsyncResult;
@@ -65,11 +73,13 @@ import io.vertx.sqlclient.Tuple;
 import iudx.aaa.server.apiserver.RegistrationRequest;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
+import iudx.aaa.server.apiserver.RevokeToken;
 import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.UpdateProfileRequest;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
+import iudx.aaa.server.token.TokenService;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,10 +113,19 @@ public class RegistrationServiceImpl implements RegistrationService {
 
   private PgPool pool;
   private KcAdmin kc;
+  private TokenService tokenService;
+  public static String AUTH_SERVER_URL = "";
+  public static List<String> SERVERS_OMITTED_FROM_TOKEN_REVOKE = new ArrayList<String>();
 
-  public RegistrationServiceImpl(PgPool pool, KcAdmin kc) {
+  /* TODO: include token service here */
+  public RegistrationServiceImpl(PgPool pool, KcAdmin kc, TokenService tokenService,
+      JsonObject options) {
     this.pool = pool;
     this.kc = kc;
+    this.tokenService = tokenService;
+    AUTH_SERVER_URL = options.getString(CONFIG_AUTH_URL);
+    SERVERS_OMITTED_FROM_TOKEN_REVOKE = options.getJsonArray(CONFIG_OMITTED_SERVERS).stream()
+        .map(x -> (String) x).collect(Collectors.toList());
   }
 
   @Override
@@ -381,122 +400,73 @@ public class RegistrationServiceImpl implements RegistrationService {
     }
 
     List<Roles> requestedRoles = request.getRoles();
-    List<Roles> registeredRoles = user.getRoles();
-    String orgId = request.getOrgId();
+    Promise<JsonObject> modification = Promise.promise();
 
-    Map<Roles, RoleStatus> roles = new HashMap<Roles, RoleStatus>();
-
-    for (Roles r : requestedRoles) {
-      roles.put(r, RoleStatus.APPROVED);
-    }
-
-    List<Roles> duplicate =
-        registeredRoles.stream().filter(requestedRoles::contains).collect(Collectors.toList());
-
-    if (duplicate.size() != 0) {
-      String dupRoles =
-          duplicate.stream().map(str -> str.name().toLowerCase()).collect(Collectors.joining(", "));
-
-      Response r = new ResponseBuilder().status(409).type(URN_ALREADY_EXISTS)
-          .title(ERR_TITLE_ROLE_EXISTS).detail(ERR_DETAIL_ROLE_EXISTS + dupRoles).build();
-      handler.handle(Future.succeededFuture(r.toJson()));
-      return this;
-    }
-
-    Future<String> email = kc.getEmailId(user.getKeycloakId());
-    Future<String> checkOrgRequired;
-
-    /* orgId is needed always for delegate reg, even if the user has registered for provider role */
-    if (requestedRoles.contains(Roles.DELEGATE)) {
-      if (orgId.toString().equals(NIL_UUID)) {
-        Response r = new ResponseBuilder().status(400).type(URN_MISSING_INFO)
-            .title(ERR_TITLE_ORG_ID_REQUIRED).detail(ERR_DETAIL_ORG_ID_REQUIRED).build();
-        handler.handle(Future.succeededFuture(r.toJson()));
-        return this;
-      }
-      checkOrgRequired = pool.withConnection(
-          conn -> conn.preparedQuery(SQL_FIND_ORG_BY_ID).execute(Tuple.of(orgId.toString())).map(
-              rows -> rows.iterator().hasNext() ? rows.iterator().next().getString("url") : null));
+    /*
+     * OpenAPI validation forces either roles+orgId or clientId, so if it is client regen, the roles
+     * array will be empty
+     */
+    if (requestedRoles.size() == 0) {
+      resetClientSecret(user, request, modification);
     } else {
-      checkOrgRequired = Future.succeededFuture(NO_ORG_CHECK);
+      addRoles(user, request, modification);
     }
 
-    Future<Void> validateOrg = CompositeFuture.all(checkOrgRequired, email).compose(x -> {
-      String url = (String) x.list().get(0);
-      String emailId = (String) x.list().get(1);
+    /* After successful modification, get user details for response */
+    Future<JsonObject> modified = modification.future();
 
-      String emailDomain = emailId.split("@")[1];
-
-      if (emailId.length() == 0) {
-        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
-            .title(ERR_TITLE_USER_NOT_KC).detail(ERR_DETAIL_USER_NOT_KC).build();
-        handler.handle(Future.succeededFuture(r.toJson()));
-        return Future.failedFuture(COMPOSE_FAILURE);
-      }
-
-      if (url == null) {
-        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
-            .title(ERR_TITLE_ORG_NO_EXIST).detail(ERR_DETAIL_ORG_NO_EXIST).build();
-        handler.handle(Future.succeededFuture(r.toJson()));
-        return Future.failedFuture(COMPOSE_FAILURE);
-
-      } else if (!url.equals(emailDomain) && !url.equals(NO_ORG_CHECK)) {
-        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
-            .title(ERR_TITLE_ORG_NO_MATCH).detail(ERR_DETAIL_ORG_NO_MATCH).build();
-        handler.handle(Future.succeededFuture(r.toJson()));
-        return Future.failedFuture(COMPOSE_FAILURE);
-      }
-
-      return Future.succeededFuture();
-    });
-
-    List<Roles> rolesForKc =
-        requestedRoles.stream().filter(x -> x != Roles.PROVIDER).collect(Collectors.toList());
-
-    List<Tuple> roleDetails = roles.entrySet().stream()
-        .map(p -> Tuple.of(user.getUserId(), p.getKey().name(), p.getValue().name()))
-        .collect(Collectors.toList());
-
-    /* supplier to create tuple for org update */
-    Supplier<Tuple> updateOrgIdTup = () -> {
-      if (checkOrgRequired.result() == NO_ORG_CHECK) {
-        return Tuple.of(null, user.getUserId());
-      }
-      return Tuple.of(request.getOrgId(), user.getUserId());
-    };
-
-    Future<Void> query = validateOrg.compose(res -> pool
-        .withTransaction(conn -> conn.preparedQuery(SQL_CREATE_ROLE).executeBatch(roleDetails)
-            .compose(success -> conn.preparedQuery(SQL_UPDATE_ORG_ID).execute(updateOrgIdTup.get()))
-            .compose(success -> kc.modifyRoles(user.getKeycloakId(), rolesForKc))));
-
-    /* After successful insertion, get user details for response */
     Future<JsonObject> phoneOrgDetails =
-        query.compose(x -> pool.withConnection(conn -> conn.preparedQuery(SQL_GET_PHONE_JOIN_ORG)
+        modified.compose(x -> pool.withConnection(conn -> conn.preparedQuery(SQL_GET_PHONE_JOIN_ORG)
             .execute(Tuple.of(user.getUserId())).map(rows -> rows.iterator().next().toJson())));
 
     Collector<Row, ?, List<JsonObject>> clientDetails =
         Collectors.mapping(row -> row.toJson(), Collectors.toList());
 
-    Future<List<JsonObject>> clientQuery = query.compose(x -> pool.withConnection(
+    Future<List<JsonObject>> clientQuery = modified.compose(x -> pool.withConnection(
         conn -> conn.preparedQuery(SQL_GET_CLIENTS_FORMATTED).collecting(clientDetails)
             .execute(Tuple.of(user.getUserId())).map(res -> res.value())));
 
-    CompositeFuture.all(phoneOrgDetails, clientQuery).onSuccess(obj -> {
+    /* TODO: kc.getEmailId is slow, already being performed at addRole. Consider using once only */
+    Future<String> getEmail = kc.getEmailId(user.getKeycloakId());
+
+    CompositeFuture.all(phoneOrgDetails, clientQuery, getEmail).onSuccess(obj -> {
       JsonObject details = (JsonObject) obj.list().get(0);
       @SuppressWarnings("unchecked")
       List<JsonObject> clients = (List<JsonObject>) obj.list().get(1);
+      String email = (String) obj.list().get(2);
 
       List<Roles> approvedRoles = new ArrayList<Roles>();
       approvedRoles.addAll(user.getRoles());
-      approvedRoles.addAll(rolesForKc);
+
+      JsonObject modifiedInfo = modified.result();
+      String title = "";
+
+      if (modifiedInfo.containsKey("roles")) {
+        approvedRoles.clear();
+        @SuppressWarnings("unchecked")
+        List<Roles> updatedRolesArray = modifiedInfo.getJsonArray("roles").getList();
+        approvedRoles.addAll(updatedRolesArray);
+        title = SUCC_TITLE_UPDATED_USER_ROLES;
+      }
+
+      if (modified.result().containsKey(RESP_CLIENT_ID)) {
+        String updatedClientId = modifiedInfo.getString(RESP_CLIENT_ID);
+        String clientSecret = modifiedInfo.getString(RESP_CLIENT_SC);
+        for (int i = 0; i < clients.size(); i++) {
+          JsonObject cli = clients.get(i);
+          if (cli.getString(RESP_CLIENT_ID).equals(updatedClientId)) {
+            clients.set(i, cli.put(RESP_CLIENT_SC, clientSecret));
+          }
+        }
+        title = SUCC_TITLE_REGEN_CLIENT_SECRET;
+      }
 
       User u = new UserBuilder()
           .name(user.getName().get("firstName"), user.getName().get("lastName"))
           .roles(approvedRoles).keycloakId(user.getKeycloakId()).userId(user.getUserId()).build();
 
       JsonObject response = u.toJsonResponse();
-      response.put(RESP_EMAIL, email.result());
+      response.put(RESP_EMAIL, email);
       response.put(RESP_CLIENT_ARR, new JsonArray(clients));
 
       String phone = (String) details.remove("phone");
@@ -509,15 +479,17 @@ public class RegistrationServiceImpl implements RegistrationService {
         response.put(RESP_ORG, details);
       }
 
-      LOGGER.info("Updated user profile for " + u.getUserId().toString() + " with roles "
-          + request.getRoles().toString());
+      LOGGER.info("Updated user profile for " + u.getUserId().toString() + " (" + title + ")");
 
-      Response r = new ResponseBuilder().type(URN_SUCCESS).title(SUCC_TITLE_UPDATED_USER_ROLES)
-          .status(200).objectResults(response).build();
+      Response r = new ResponseBuilder().type(URN_SUCCESS).title(title).status(200)
+          .objectResults(response).build();
       handler.handle(Future.succeededFuture(r.toJson()));
     }).onFailure(e -> {
-      if (e.getMessage().equals(COMPOSE_FAILURE)) {
-        return; // do nothing
+
+      if (e instanceof ComposeException) {
+        ComposeException exp = (ComposeException) e;
+        handler.handle(Future.succeededFuture(exp.getResponse().toJson()));
+        return;
       }
       LOGGER.error(e.getMessage());
       handler.handle(Future.failedFuture("Internal error"));
@@ -609,6 +581,249 @@ public class RegistrationServiceImpl implements RegistrationService {
     });
 
     return this;
+  }
+
+  /**
+   * Add roles to a user's user profile. Only consumer and delegate can be added currently. The
+   * promise argument succeeds with a JSON object containing the updated array of roles the user
+   * has, <i>roles</i>. The promise argument fails with a ComposeException in case of an expected
+   * error.
+   * 
+   * @param user The User object for the user who wants to add roles
+   * @param request The UpdateProfileRequest object containing the requested roles array and
+   *        organization ID
+   * @param promise A Promise indicating the success/failure of the operation
+   */
+  public void addRoles(User user, UpdateProfileRequest request, Promise<JsonObject> promise) {
+
+    List<Roles> registeredRoles = user.getRoles();
+    List<Roles> requestedRoles = request.getRoles();
+    String orgId = request.getOrgId();
+
+    Map<Roles, RoleStatus> roles = new HashMap<Roles, RoleStatus>();
+
+    for (Roles r : requestedRoles) {
+      roles.put(r, RoleStatus.APPROVED);
+    }
+
+    List<Roles> duplicate =
+        registeredRoles.stream().filter(requestedRoles::contains).collect(Collectors.toList());
+
+    if (duplicate.size() != 0) {
+      String dupRoles =
+          duplicate.stream().map(str -> str.name().toLowerCase()).collect(Collectors.joining(", "));
+
+      Response r = new ResponseBuilder().status(409).type(URN_ALREADY_EXISTS)
+          .title(ERR_TITLE_ROLE_EXISTS).detail(ERR_DETAIL_ROLE_EXISTS + dupRoles).build();
+      promise.fail(new ComposeException(r));
+      return;
+    }
+
+    Future<String> email = kc.getEmailId(user.getKeycloakId());
+    Future<String> checkOrgRequired;
+
+    /* orgId is needed always for delegate reg, even if the user has registered for provider role */
+    if (requestedRoles.contains(Roles.DELEGATE)) {
+      if (orgId.toString().equals(NIL_UUID)) {
+        Response r = new ResponseBuilder().status(400).type(URN_MISSING_INFO)
+            .title(ERR_TITLE_ORG_ID_REQUIRED).detail(ERR_DETAIL_ORG_ID_REQUIRED).build();
+        promise.fail(new ComposeException(r));
+        return;
+      }
+      checkOrgRequired = pool.withConnection(
+          conn -> conn.preparedQuery(SQL_FIND_ORG_BY_ID).execute(Tuple.of(orgId.toString())).map(
+              rows -> rows.iterator().hasNext() ? rows.iterator().next().getString("url") : null));
+    } else {
+      checkOrgRequired = Future.succeededFuture(NO_ORG_CHECK);
+    }
+
+    Future<Void> validateOrg = CompositeFuture.all(checkOrgRequired, email).compose(x -> {
+      String url = (String) x.list().get(0);
+      String emailId = (String) x.list().get(1);
+
+      String emailDomain = emailId.split("@")[1];
+
+      if (emailId.length() == 0) {
+        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
+            .title(ERR_TITLE_USER_NOT_KC).detail(ERR_DETAIL_USER_NOT_KC).build();
+        return Future.failedFuture(new ComposeException(r));
+      }
+
+      if (url == null) {
+        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
+            .title(ERR_TITLE_ORG_NO_EXIST).detail(ERR_DETAIL_ORG_NO_EXIST).build();
+        return Future.failedFuture(new ComposeException(r));
+
+      } else if (!url.equals(emailDomain) && !url.equals(NO_ORG_CHECK)) {
+        Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
+            .title(ERR_TITLE_ORG_NO_MATCH).detail(ERR_DETAIL_ORG_NO_MATCH).build();
+        return Future.failedFuture(new ComposeException(r));
+      }
+
+      return Future.succeededFuture();
+    });
+
+    List<Roles> rolesForKc =
+        requestedRoles.stream().filter(x -> x != Roles.PROVIDER).collect(Collectors.toList());
+
+    List<Tuple> roleDetails = roles.entrySet().stream()
+        .map(p -> Tuple.of(user.getUserId(), p.getKey().name(), p.getValue().name()))
+        .collect(Collectors.toList());
+
+    /* supplier to create tuple for org update */
+    Supplier<Tuple> updateOrgIdTup = () -> {
+      if (checkOrgRequired.result() == NO_ORG_CHECK) {
+        return Tuple.of(null, user.getUserId());
+      }
+      return Tuple.of(request.getOrgId(), user.getUserId());
+    };
+
+    Future<Void> performUpdate = validateOrg.compose(res -> pool
+        .withTransaction(conn -> conn.preparedQuery(SQL_CREATE_ROLE).executeBatch(roleDetails)
+            .compose(success -> conn.preparedQuery(SQL_UPDATE_ORG_ID).execute(updateOrgIdTup.get()))
+            .compose(success -> kc.modifyRoles(user.getKeycloakId(), rolesForKc))));
+
+    performUpdate.onSuccess(success -> {
+      /*
+       * TODO: the .getRoles() method in the User object returns the roles array by reference. We
+       * make a copy of said list here. The proper fix would be for the getter to either send a copy
+       * or an unmodifiable list.
+       */
+      List<Roles> updatedRoles = new ArrayList<Roles>(user.getRoles());
+      updatedRoles.addAll(rolesForKc);
+
+      JsonObject resp = new JsonObject().put("roles", updatedRoles);
+      promise.complete(resp);
+    }).onFailure(e -> {
+      if (e instanceof ComposeException) {
+        promise.fail(e);
+        return;
+      }
+
+      LOGGER.error(e.getMessage());
+      promise.fail("Internal error");
+    });
+    return;
+  }
+
+  /**
+   * Reset client secret of a particular client ID for a user. The promise argument succeeds with a
+   * JSON object containing the client ID <i>clientId</i> and the regenerated client secret
+   * <i>clientSecret</i>. The promise argument fails with a ComposeException in case of an expected
+   * error.
+   * 
+   * @param user The User object for the user who wants to reset client secret
+   * @param request The UpdateProfileRequest object containing the client ID
+   * @param promise A Promise indicating the success/failure of the operation
+   */
+  public void resetClientSecret(User user, UpdateProfileRequest request,
+      Promise<JsonObject> promise) {
+    UUID userId = UUID.fromString(user.getUserId());
+    UUID clientId = UUID.fromString(request.getClientId());
+
+    Tuple tuple = Tuple.of(clientId, userId);
+    Future<Void> checkClientId =
+        pool.withConnection(conn -> conn.preparedQuery(SQL_CHECK_CLIENT_ID_EXISTS).execute(tuple)
+            .map(row -> row.iterator().next().getBoolean(0))).compose(res -> {
+              if (!res) {
+                Response r = new ResponseBuilder().status(404).type(URN_INVALID_INPUT)
+                    .title(ERR_TITLE_INVALID_CLI_ID).detail(ERR_DETAIL_INVALID_CLI_ID).build();
+                return Future.failedFuture(new ComposeException(r));
+              }
+              return Future.succeededFuture();
+            });
+
+    Future<List<RevokeToken>> tokenRevokeReq = checkClientId.compose(success -> {
+      /* Collector to create list of TokenRevoke requests from list of resource_server urls */
+      Collector<Row, ?, List<RevokeToken>> getTokenRevokeReqList = Collectors.mapping(row -> {
+        JsonObject revokeReq = new JsonObject().put("rsUrl", row.getString("url"));
+        return new RevokeToken(revokeReq);
+      }, Collectors.toList());
+
+      /*
+       * We can choose to omit some servers from the revocation required during client secret regen
+       * by adding them to the config. (Currently no server needs to be revoked since we don't
+       * bother if a revocation succeeds (HTTP 200) or fails (any other status code, DNS error))
+       */
+      List<String> omittedServers = SERVERS_OMITTED_FROM_TOKEN_REVOKE;
+      omittedServers.add(AUTH_SERVER_URL);
+
+      return pool.withConnection(
+          conn -> conn.preparedQuery(SQL_GET_SERVERS_FOR_REVOKE).collecting(getTokenRevokeReqList)
+              .execute(Tuple.of(omittedServers.toArray(String[]::new))).map(res -> res.value()));
+    });
+
+    Future<CompositeFuture> tokenRevokeResult = tokenRevokeReq.compose(revReq -> {
+      @SuppressWarnings("rawtypes")
+      List<Future> futures = new ArrayList<Future>();
+      futures = revReq.stream().map(req -> callTokenRevoke(user, req)).collect(Collectors.toList());
+      return CompositeFuture.all(futures);
+    });
+
+    tokenRevokeResult.compose(revokedAll -> {
+      /*
+       * TODO: callTokenRevoke only fails in case there's an internal error from the tokenRevoke
+       * service. It returns all succeeded futures of Boolean type, true if 200 OK, false if not. We
+       * currently do not check if the bool is true or false, we only know that the future has
+       * succeeded. Later on, we need to act on instances where the bool = false, i.e. the token
+       * revoke call to that particular server has failed. retry logic?, store info about revoke and
+       * expose an API to servers?
+       */
+      SecureRandom random = new SecureRandom();
+      byte[] randBytes = new byte[CLIENT_SECRET_BYTES];
+      random.nextBytes(randBytes);
+      String clientSecret = Hex.encodeHexString(randBytes);
+      String hashedClientSecret = DigestUtils.sha512Hex(clientSecret);
+      Tuple tup = Tuple.of(hashedClientSecret, clientId, userId);
+
+      return pool.withConnection(
+          conn -> conn.preparedQuery(SQL_UPDATE_CLIENT_SECRET).execute(tup).map(clientSecret));
+    }).onSuccess(cliSec -> {
+      JsonObject clientDets =
+          new JsonObject().put(RESP_CLIENT_ID, clientId.toString()).put(RESP_CLIENT_SC, cliSec);
+      promise.complete(clientDets);
+
+    }).onFailure(e -> {
+      if (e instanceof ComposeException) {
+        promise.fail(e);
+        return;
+      }
+
+      LOGGER.error(e.getMessage());
+      promise.fail("Internal error");
+    });
+    return;
+  }
+
+  /**
+   * Calls the revokeToken method in the TokenService. A Boolean future is returned. A succeeded
+   * future with <i>true</i> is returned if the revoke is successful.A A succeeded future with
+   * <i>false</i> is returned if the revocation fails due to expected errors e.g. server not
+   * reachable, responded incorrectly etc. <b>A failed future is returned if the revocation fails
+   * unexpected like e.g. due to an internal error.</b>
+   * 
+   * @param user The User object for the user for whom the tokens must be revoked
+   * @param request A RevokeToken request object containing the server URL to be revoked
+   * @return a Boolean future
+   */
+  private Future<Boolean> callTokenRevoke(User user, RevokeToken request) {
+    Promise<Boolean> response = Promise.promise();
+    Promise<JsonObject> promise = Promise.promise();
+
+    tokenService.revokeToken(request, user, promise);
+    promise.future().onSuccess(resp -> {
+      if (resp.getString("type").equals(URN_SUCCESS)) {
+        response.complete(true);
+      } else {
+        response.complete(false);
+        LOGGER.error("Failed to revoke tokens on " + request.getRsUrl());
+      }
+
+    }).onFailure(err -> {
+      response.fail("Future failed - Failed to revoke tokens on " + request.getRsUrl());
+      LOGGER.error(err.getLocalizedMessage());
+    });
+    return response.future();
   }
 
   public void searchUser(User user, JsonObject searchUserDetails, Boolean isAuthDelegate,

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -427,7 +427,7 @@ public class RegistrationServiceImpl implements RegistrationService {
             .execute(Tuple.of(user.getUserId())).map(res -> res.value())));
 
     /* TODO: kc.getEmailId is slow, already being performed at addRole. Consider using once only */
-    Future<String> getEmail = kc.getEmailId(user.getKeycloakId());
+    Future<String> getEmail = modified.compose(x -> kc.getEmailId(user.getKeycloakId()));
 
     CompositeFuture.all(phoneOrgDetails, clientQuery, getEmail).onSuccess(obj -> {
       JsonObject details = (JsonObject) obj.list().get(0);
@@ -641,13 +641,13 @@ public class RegistrationServiceImpl implements RegistrationService {
       String url = (String) x.list().get(0);
       String emailId = (String) x.list().get(1);
 
-      String emailDomain = emailId.split("@")[1];
-
       if (emailId.length() == 0) {
         Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
             .title(ERR_TITLE_USER_NOT_KC).detail(ERR_DETAIL_USER_NOT_KC).build();
         return Future.failedFuture(new ComposeException(r));
       }
+
+      String emailDomain = emailId.split("@")[1];
 
       if (url == null) {
         Response r = new ResponseBuilder().status(400).type(URN_INVALID_INPUT)

--- a/src/main/java/iudx/aaa/server/registration/RegistrationVerticle.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationVerticle.java
@@ -1,5 +1,7 @@
 package iudx.aaa.server.registration;
 
+import static iudx.aaa.server.registration.Constants.CONFIG_AUTH_URL;
+import static iudx.aaa.server.registration.Constants.CONFIG_OMITTED_SERVERS;
 import static iudx.aaa.server.registration.Constants.DATABASE_IP;
 import static iudx.aaa.server.registration.Constants.DB_CONNECT_TIMEOUT;
 import static iudx.aaa.server.registration.Constants.DATABASE_NAME;
@@ -13,6 +15,7 @@ import static iudx.aaa.server.registration.Constants.KC_ADMIN_CLIENT_SEC;
 import static iudx.aaa.server.registration.Constants.KC_ADMIN_POOLSIZE;
 import static iudx.aaa.server.registration.Constants.KEYCLOAK_REALM;
 import static iudx.aaa.server.registration.Constants.KEYCLOAK_URL;
+
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +26,7 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.token.TokenService;
 
 /**
  * The Registration Verticle.
@@ -56,11 +60,15 @@ public class RegistrationVerticle extends AbstractVerticle {
   private PgPool pool;
   private PoolOptions poolOptions;
   private PgConnectOptions connectOptions;
+  private static JsonObject options;
   private static final String REGISTRATION_SERVICE_ADDRESS = "iudx.aaa.registration.service";
+  private static final String TOKEN_SERVICE_ADDRESS = "iudx.aaa.token.service";
   private RegistrationService registrationService;
   private ServiceBinder binder;
   private MessageConsumer<JsonObject> consumer;
   private static final Logger LOGGER = LogManager.getLogger(RegistrationVerticle.class);
+  
+  private TokenService tokenService;
 
   /**
    * This method is used to start the Verticle. It deploys a verticle in a cluster, registers the
@@ -88,6 +96,9 @@ public class RegistrationVerticle extends AbstractVerticle {
     keycloakAdminClientSecret = config().getString(KC_ADMIN_CLIENT_SEC);
     keycloakAdminPoolSize = Integer.parseInt(config().getString(KC_ADMIN_POOLSIZE));
 
+    options = new JsonObject().put(CONFIG_AUTH_URL, config().getString(CONFIG_AUTH_URL))
+        .put(CONFIG_OMITTED_SERVERS, config().getJsonArray(CONFIG_OMITTED_SERVERS));
+
     /* Set Connection Object and schema */
     if (connectOptions == null) {
       Map<String, String> schemaProp = Map.of("search_path", databaseSchema);
@@ -108,7 +119,8 @@ public class RegistrationVerticle extends AbstractVerticle {
     KcAdmin kcadmin = new KcAdmin(keycloakUrl, keycloakRealm, keycloakAdminClientId,
         keycloakAdminClientSecret, keycloakAdminPoolSize);
 
-    registrationService = new RegistrationServiceImpl(pool, kcadmin);
+    tokenService = TokenService.createProxy(vertx, TOKEN_SERVICE_ADDRESS);
+    registrationService = new RegistrationServiceImpl(pool, kcadmin, tokenService, options);
     binder = new ServiceBinder(vertx);
     consumer = binder.setAddress(REGISTRATION_SERVICE_ADDRESS)
         .register(RegistrationService.class, registrationService);

--- a/src/main/resources/postman/IUDX-AAA-Server.postman_collection.json
+++ b/src/main/resources/postman/IUDX-AAA-Server.postman_collection.json
@@ -514,6 +514,105 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Update user (regenerate client secret)",
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "authUrl",
+									"value": "{{KEYCLOAK_ENDPOINT}}/auth/realms/{{KEYCLOAK_REALM}}/protocol/openid-connect/auth",
+									"type": "string"
+								},
+								{
+									"key": "state",
+									"value": "{{$randomAlphaNumeric}}",
+									"type": "string"
+								},
+								{
+									"key": "accessTokenUrl",
+									"value": "{{KEYCLOAK_ENDPOINT}}/auth/realms/{{KEYCLOAK_REALM}}/protocol/openid-connect/token",
+									"type": "string"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{KEYCLOAK_ENDPOINT}}/auth/realms/{{KEYCLOAK_REALM}}/account/callback",
+									"type": "string"
+								},
+								{
+									"key": "tokenName",
+									"value": "Token",
+									"type": "string"
+								},
+								{
+									"key": "useBrowser",
+									"value": false,
+									"type": "boolean"
+								},
+								{
+									"key": "scope",
+									"value": "email",
+									"type": "string"
+								},
+								{
+									"key": "clientSecret",
+									"value": "",
+									"type": "string"
+								},
+								{
+									"key": "clientId",
+									"value": "account",
+									"type": "string"
+								},
+								{
+									"key": "grant_type",
+									"value": "authorization_code",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "{{provider_password}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{provider_username}}",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clientId\": \"7b35dd25-2b2e-47d1-93d1-be8ab12965fa\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
@@ -1,6 +1,8 @@
 package iudx.aaa.server.registration;
 
 import static iudx.aaa.server.apiserver.util.Urn.*;
+import static iudx.aaa.server.registration.Constants.CONFIG_AUTH_URL;
+import static iudx.aaa.server.registration.Constants.CONFIG_OMITTED_SERVERS;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_SEARCH_USR_INVALID_ROLE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_FOUND;
@@ -31,6 +33,7 @@ import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.token.TokenService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +69,9 @@ public class SearchUserTest {
   private static Vertx vertxObj;
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
+  private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static JsonObject options = new JsonObject();
+  
   private static final String UUID_REGEX =
       "^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$";
 
@@ -110,6 +116,8 @@ public class SearchUserTest {
 
     pool = PgPool.pool(vertx, connectOptions, poolOptions);
 
+    options.put(CONFIG_AUTH_URL, dbConfig.getString(CONFIG_AUTH_URL)).put(CONFIG_OMITTED_SERVERS,
+        dbConfig.getJsonArray(CONFIG_OMITTED_SERVERS));
     /*
      * create fake organization, and create 2 mock users. One user has an organization + phone
      * number other does not
@@ -131,7 +139,7 @@ public class SearchUserTest {
     consumerAdmin = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesB, false);
 
     CompositeFuture.all(providerDeleg, consumerAdmin).onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc);
+      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
@@ -1,25 +1,36 @@
 package iudx.aaa.server.registration;
 
 import static iudx.aaa.server.apiserver.util.Urn.*;
+import static iudx.aaa.server.registration.Constants.CLIENT_SECRET_BYTES;
+import static iudx.aaa.server.registration.Constants.CONFIG_AUTH_URL;
+import static iudx.aaa.server.registration.Constants.CONFIG_OMITTED_SERVERS;
+import static iudx.aaa.server.registration.Constants.ERR_DETAIL_INVALID_CLI_ID;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_NO_EXIST;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ORG_NO_MATCH;
 import static iudx.aaa.server.registration.Constants.ERR_DETAIL_ROLE_EXISTS;
+import static iudx.aaa.server.registration.Constants.ERR_DETAIL_USER_NOT_KC;
+import static iudx.aaa.server.registration.Constants.ERR_TITLE_INVALID_CLI_ID;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_NO_USER_PROFILE;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ORG_ID_REQUIRED;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ORG_NO_EXIST;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ORG_NO_MATCH;
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_ROLE_EXISTS;
+import static iudx.aaa.server.registration.Constants.ERR_TITLE_USER_NOT_KC;
 import static iudx.aaa.server.registration.Constants.NIL_UUID;
 import static iudx.aaa.server.registration.Constants.RESP_CLIENT_ARR;
 import static iudx.aaa.server.registration.Constants.RESP_CLIENT_ID;
+import static iudx.aaa.server.registration.Constants.RESP_CLIENT_SC;
 import static iudx.aaa.server.registration.Constants.RESP_EMAIL;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.RESP_PHONE;
+import static iudx.aaa.server.registration.Constants.SUCC_TITLE_REGEN_CLIENT_SECRET;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_UPDATED_USER_ROLES;
+import static iudx.aaa.server.registration.Utils.SQL_CREATE_ADMIN_SERVER;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
+import static iudx.aaa.server.registration.Utils.SQL_DELETE_SERVERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,12 +48,14 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apiserver.RevokeToken;
 import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.UpdateProfileRequest;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.token.TokenService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,13 +92,27 @@ public class UpdateUserTest {
   private static Vertx vertxObj;
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
+  private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static JsonObject options = new JsonObject();
 
   static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
   static String url = name + ".com";
   static Promise<UUID> orgId;
+  static Future<JsonObject> adminUser;
+
+  private static final String DUMMY_AUTH_SERVER =
+      "auth" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + "iudx.io";
+
+  private static final String DUMMY_SERVER_1 =
+      "dummy" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
+
+  private static final String DUMMY_SERVER_2 =
+      "dummy" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
 
   static Future<UUID> orgIdFut;
   static List<JsonObject> createdUsers = new ArrayList<JsonObject>();
+  private static final int CLIENT_SECRET_HEX_LEN = CLIENT_SECRET_BYTES * 2;
+  private static final String CLIENT_SECRET_REGEX = "^[0-9a-f]{" + CLIENT_SECRET_HEX_LEN + "}$";
 
   @BeforeAll
   @DisplayName("Deploying Verticle")
@@ -109,9 +136,9 @@ public class UpdateUserTest {
     if (connectOptions == null) {
       Map<String, String> schemaProp = Map.of("search_path", databaseSchema);
 
-      connectOptions = new PgConnectOptions().setPort(databasePort).setHost(databaseIP)
-          .setDatabase(databaseName).setUser(databaseUserName).setPassword(databasePassword)
-          .setProperties(schemaProp);
+      connectOptions =
+          new PgConnectOptions().setPort(databasePort).setHost(databaseIP).setDatabase(databaseName)
+              .setUser(databaseUserName).setPassword(databasePassword).setProperties(schemaProp);
     }
 
     if (poolOptions == null) {
@@ -120,13 +147,38 @@ public class UpdateUserTest {
 
     pool = PgPool.pool(vertx, connectOptions, poolOptions);
 
-    /* create fake organization. */
+    /*
+     * We inject the DUMMY_AUTH_SERVER url in the config. The servers that need to be omitted can be
+     * in config-test itself
+     */
+    options.put(CONFIG_AUTH_URL, DUMMY_AUTH_SERVER).put(CONFIG_OMITTED_SERVERS,
+        dbConfig.getJsonArray(CONFIG_OMITTED_SERVERS));
 
+    /* create fake organization for registration */
     orgIdFut = pool.withConnection(conn -> conn.preparedQuery(SQL_CREATE_ORG)
         .execute(Tuple.of(name, url)).map(row -> row.iterator().next().getUUID("id")));
 
-    orgIdFut.onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc);
+    /*
+     * we create a fake auth and 2 dummy servers to test out the revocation logic, so as to not
+     * affect any real servers in test. We also need to create an admin user since we need a valid
+     * user ID when inserting into the resource_server table.
+     */
+    adminUser = orgIdFut.compose(id -> Utils.createFakeUser(pool, id.toString(), url,
+        Map.of(Roles.ADMIN, RoleStatus.APPROVED), true));
+
+    adminUser.compose(adminDetails -> {
+      UUID adUid = UUID.fromString(adminDetails.getString("userId"));
+
+      createdUsers.add(adminDetails);
+
+      List<Tuple> servers = List.of(Tuple.of("Auth Server", adUid, DUMMY_AUTH_SERVER),
+          Tuple.of("Other Server One", adUid, DUMMY_SERVER_1),
+          Tuple.of("Other Server Two", adUid, DUMMY_SERVER_2));
+
+      return pool.withConnection(
+          conn -> conn.preparedQuery(SQL_CREATE_ADMIN_SERVER).executeBatch(servers));
+    }).onSuccess(res -> {
+      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }
@@ -135,9 +187,11 @@ public class UpdateUserTest {
   public static void finish(VertxTestContext testContext) {
     LOGGER.info("Finishing and resetting DB");
 
-    Utils.deleteFakeUser(pool, createdUsers)
-        .compose(success -> pool.withConnection(
-            conn -> conn.preparedQuery(SQL_DELETE_ORG).execute(Tuple.of(orgIdFut.result()))))
+    Tuple servers = Tuple.of(List.of(DUMMY_AUTH_SERVER, DUMMY_SERVER_1, DUMMY_SERVER_2).toArray());
+
+    pool.withConnection(conn -> conn.preparedQuery(SQL_DELETE_SERVERS).execute(servers)
+        .compose(success -> Utils.deleteFakeUser(pool, createdUsers))
+        .compose(succ -> conn.preparedQuery(SQL_DELETE_ORG).execute(Tuple.of(orgIdFut.result()))))
         .onComplete(x -> {
           if (x.failed()) {
             LOGGER.warn(x.cause().getMessage());
@@ -168,7 +222,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test no org ID when consumer requesting delegate")
+  @DisplayName("[Update roles] Test no org ID when consumer requesting delegate")
   void consumerNoOrgId(VertxTestContext testContext) {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate"));
 
@@ -202,7 +256,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test invalid org Id when getting delegate")
+  @DisplayName("[Update roles] Test invalid org Id when getting delegate")
   void consumerInvalidOrg(VertxTestContext testContext) {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
         UUID.randomUUID().toString());
@@ -237,7 +291,42 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test consumer with gmail email cannot become delegate")
+  @DisplayName("[Update roles] Test email not found on keycloak - should never happen")
+  void emailNotFoundOnKeycloak(VertxTestContext testContext) {
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
+        UUID.randomUUID().toString());
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.CONSUMER);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.CONSUMER, RoleStatus.APPROVED);
+
+    Future<JsonObject> consumer = Utils.createFakeUser(pool, NIL_UUID, "", cons, false);
+
+    consumer.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(""));
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(400, response.getInteger("status"));
+            assertEquals(ERR_TITLE_USER_NOT_KC, response.getString("title"));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
+            assertEquals(ERR_DETAIL_USER_NOT_KC, response.getString("detail"));
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
+  @DisplayName("[Update roles] Test consumer with gmail email cannot become delegate")
   void consumerDomainMismatch(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
@@ -274,7 +363,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test consumer get delegate roles")
+  @DisplayName("[Update roles] Test consumer get delegate roles")
   void consumerAddProvDele(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
@@ -337,7 +426,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test existing role request")
+  @DisplayName("[Update roles] Test existing role request")
   void existingRoles(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer").add("delegate"))
@@ -379,7 +468,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test pending provider getting consumer and delegate roles - with and without orgId")
+  @DisplayName("[Update roles] Test pending provider getting consumer and delegate roles - with and without orgId")
   void providerGettingConsDele(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer").add("delegate"));
@@ -463,7 +552,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("Test provider getting consumer with keycloak transaction failure ")
+  @DisplayName("[Update roles] Test provider getting consumer with keycloak transaction failure ")
   void keycloakFailure(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer"));
@@ -532,6 +621,226 @@ public class UpdateUserTest {
               testContext.completeNow();
             })));
       });
+    });
+  }
+
+  @Test
+  @DisplayName("[Regen Client Secret] Successfully regen client secret")
+  void clientRegenSuccess(VertxTestContext testContext) {
+
+    List<Roles> roles = List.of(Roles.DELEGATE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.DELEGATE, RoleStatus.APPROVED);
+
+    Future<JsonObject> provDele =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), url, cons, false);
+
+    provDele.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+      JsonObject req = new JsonObject().put("clientId", userJson.getString("clientId"));
+
+      UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      Mockito.doAnswer(i -> {
+        Promise<JsonObject> p = i.getArgument(2);
+        p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
+        return i.getMock();
+      }).when(tokenService).revokeToken(any(), any(), any());
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(200, response.getInteger("status"));
+            assertEquals(SUCC_TITLE_REGEN_CLIENT_SECRET, response.getString("title"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
+
+            JsonObject result = response.getJsonObject("results");
+
+            JsonObject name = result.getJsonObject("name");
+            assertEquals(name.getString("firstName"), userJson.getString("firstName"));
+            assertEquals(name.getString("lastName"), userJson.getString("lastName"));
+
+            @SuppressWarnings("unchecked")
+            List<String> returnedRoles = result.getJsonArray("roles").getList();
+            List<String> rolesString = List.of(Roles.DELEGATE.name().toLowerCase());
+            assertTrue(
+                returnedRoles.containsAll(rolesString) && rolesString.containsAll(returnedRoles));
+
+            JsonArray clients = result.getJsonArray(RESP_CLIENT_ARR);
+            JsonObject defaultClient = clients.getJsonObject(0);
+            assertTrue(clients.size() > 0);
+            assertEquals(defaultClient.getString(RESP_CLIENT_ID), userJson.getString("clientId"));
+            assertTrue(defaultClient.containsKey(RESP_CLIENT_SC));
+            String newClientSec = defaultClient.getString(RESP_CLIENT_SC);
+            assertTrue(newClientSec.matches(CLIENT_SECRET_REGEX));
+            String oldClientSec = userJson.getString("clientSecret");
+            assertFalse(oldClientSec.equals(newClientSec));
+
+            JsonObject org = result.getJsonObject(RESP_ORG);
+            assertEquals(org.getString("url"), userJson.getString("url"));
+
+            assertEquals(result.getString(RESP_EMAIL), userJson.getString("email"));
+            assertEquals(result.getString("userId"), userJson.getString("userId"));
+            assertEquals(result.getString("keycloakId"), userJson.getString("keycloakId"));
+
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
+  @DisplayName("[Regen Client Secret] Success when some token revoke to a server fails")
+  void clientRegenSuccess2(VertxTestContext testContext) {
+
+    List<Roles> roles = List.of(Roles.DELEGATE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.DELEGATE, RoleStatus.APPROVED);
+
+    Future<JsonObject> provDele =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), url, cons, false);
+
+    provDele.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+      JsonObject req = new JsonObject().put("clientId", userJson.getString("clientId"));
+
+      UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      Mockito.doAnswer(i -> {
+        Promise<JsonObject> p = i.getArgument(2);
+        RevokeToken r = i.getArgument(0);
+        if (r.getRsUrl().equals(DUMMY_SERVER_2)) {
+          p.complete(new JsonObject().put("type", URN_INVALID_INPUT.toString()));
+        } else {
+          p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
+        }
+        return i.getMock();
+      }).when(tokenService).revokeToken(any(), any(), any());
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(200, response.getInteger("status"));
+            assertEquals(SUCC_TITLE_REGEN_CLIENT_SECRET, response.getString("title"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
+
+            JsonObject result = response.getJsonObject("results");
+
+            JsonObject name = result.getJsonObject("name");
+            assertEquals(name.getString("firstName"), userJson.getString("firstName"));
+            assertEquals(name.getString("lastName"), userJson.getString("lastName"));
+
+            @SuppressWarnings("unchecked")
+            List<String> returnedRoles = result.getJsonArray("roles").getList();
+            List<String> rolesString = List.of(Roles.DELEGATE.name().toLowerCase());
+            assertTrue(
+                returnedRoles.containsAll(rolesString) && rolesString.containsAll(returnedRoles));
+
+            JsonArray clients = result.getJsonArray(RESP_CLIENT_ARR);
+            JsonObject defaultClient = clients.getJsonObject(0);
+            assertTrue(clients.size() > 0);
+            assertEquals(defaultClient.getString(RESP_CLIENT_ID), userJson.getString("clientId"));
+            assertTrue(defaultClient.containsKey(RESP_CLIENT_SC));
+            String newClientSec = defaultClient.getString(RESP_CLIENT_SC);
+            assertTrue(newClientSec.matches(CLIENT_SECRET_REGEX));
+            String oldClientSec = userJson.getString("clientSecret");
+            assertFalse(oldClientSec.equals(newClientSec));
+
+            JsonObject org = result.getJsonObject(RESP_ORG);
+            assertEquals(org.getString("url"), userJson.getString("url"));
+
+            assertEquals(result.getString(RESP_EMAIL), userJson.getString("email"));
+            assertEquals(result.getString("userId"), userJson.getString("userId"));
+            assertEquals(result.getString("keycloakId"), userJson.getString("keycloakId"));
+
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
+  @DisplayName("[Regen Client Secret] Fail when token revoke fails due to internal error")
+  void clientRegenFail(VertxTestContext testContext) {
+
+    List<Roles> roles = List.of(Roles.DELEGATE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.DELEGATE, RoleStatus.APPROVED);
+
+    Future<JsonObject> provDele =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), url, cons, false);
+
+    provDele.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+      JsonObject req = new JsonObject().put("clientId", userJson.getString("clientId"));
+
+      UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      /* Revocation to DUMMY_SERVER_2 fails with an internal error */
+      Mockito.doAnswer(i -> {
+        Promise<JsonObject> p = i.getArgument(2);
+        RevokeToken r = i.getArgument(0);
+        if (r.getRsUrl().equals(DUMMY_SERVER_2)) {
+          p.fail("Internal error");
+        } else {
+          p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
+        }
+        return i.getMock();
+      }).when(tokenService).revokeToken(any(), any(), any());
+
+      registrationService.updateUser(request, user,
+          testContext.failing(response -> testContext.verify(() -> testContext.completeNow())));
+    });
+  }
+
+  @Test
+  @DisplayName("[Regen Client Secret] Client ID not found")
+  void clientSecretRegenClientIdNotFound(VertxTestContext testContext) {
+    JsonObject req = new JsonObject().put("clientId", UUID.randomUUID().toString());
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.CONSUMER);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.CONSUMER, RoleStatus.APPROVED);
+
+    Future<JsonObject> consumer = Utils.createFakeUser(pool, NIL_UUID, "", cons, false);
+
+    consumer.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+      
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(404, response.getInteger("status"));
+            assertEquals(ERR_TITLE_INVALID_CLI_ID, response.getString("title"));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
+            assertEquals(ERR_DETAIL_INVALID_CLI_ID, response.getString("detail"));
+            testContext.completeNow();
+          })));
     });
   }
 }


### PR DESCRIPTION
configs/*
---------
- Added commonOptions and omittedServers array to skip auth server
and other servers (if desired) when revoking

docs/openapi.yaml
-----------------
- Updated OpenAPI spec to handle new request body for the
PUT /user/profile API
- Updated documentation

UpdateProfileRequest
--------------------
- Added `clientId`

ComposeException
----------------
- Added ComposeException to help when failing promises inside
services or methods called by services
- We can fail a future with a Throwable and catch the failure in an
`onFailure` block using `instanceof`

RegistrationService
-------------------
- Updated Javadoc

RegistrationVerticle
--------------------
- Updated to handle the new RegistrationServiceImpl constructor

RegistrationServiceImpl
-----------------------
- Added dependency on TokenService for revocation
- Added options JSON object for configs
- Added `resetClientSecret` method (and `callTokenRevoke` for helping)
- Moved role updation login to `addRoles` method
- Updated `updateUser` to call the appropriate method and then return
the updated User object

Tests
--------
- Updated all Registration Service tests for new RegServiceImpl constructor
- Added tests for client secret regen (one for role also for coverage)