### PR TITLE
Changes to registration APIs for trustee (APD Admin)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -744,6 +744,7 @@ paths:
           - manage catalogue items
           - manage data on resource servers
           - manage policies
+        - **trustee**, which allows a user to manage an Access Policy Domain (APD)
           
         ## Client ID and Client Secret
         On successful creation of the user profile, the user would receive a client ID and a client secret. The client ID and client secret can be used instead of the OIDC flow to request for tokens. **The client secret is ONLY shown to the user here and can never be obtained again.**
@@ -761,13 +762,14 @@ paths:
                   type: array
                   minItems: 1
                   uniqueItems: true
-                  maxItems: 3
+                  maxItems: 4
                   items:
                     type: string
                     enum:
                       - provider
                       - consumer
                       - delegate
+                      - trustee
                     minLength: 5
                     maxLength: 10
                 orgId:
@@ -794,7 +796,7 @@ paths:
                   orgId: 123e4567-e89b-12d3-a456-426614174000
         description: |-
           - `orgId` is a valid organization ID obtain from the `GET /auth/v1/organizations` API
-          - **`orgId` is required for `provider` and `delegate` roles**
+          - **`orgId` is required for `provider`, `delegate` and `trustee` roles**
           - **The domain of the email address of the registering user must match the organization domain**
         required: true
       tags:
@@ -1056,7 +1058,11 @@ paths:
         The response contains user details such as roles, name, email. It also lists the client ID of the user.
 
         ## Search for a user
-        A user with `provider` or `admin` role or is a auth delegate may search for a user by providing the email address and role of said user. If a user exists, then the user ID `userId`, email, name and organization details (if applicable) is returned.
+        A user with either 
+        - `provider` role
+        - `admin` role
+        - is an **auth delegate** 
+        may search for a user by providing the email address and role of said user. If a user exists, then the user ID `userId`, email, name and organization details (if applicable) is returned.
 
         To search for the user, 2 headers `email` (email address of user) and `role` (role of the user) need to be included. **Both headers need to be present for the search to be attempted.** If an auth delegate is to call the API, the `providerId` header needs to be included. Users with roles `delegate`, `consumer` and `provider` can be searched for.
       tags:
@@ -1187,6 +1193,7 @@ paths:
                       roles:
                         - consumer
                         - delegate
+                        - trustee
                       userId: 67194fc9-495e-40f7-b016-4470c1d4397f
                       clients:
                         - clientName: default
@@ -1279,7 +1286,7 @@ paths:
         **NOTE: The operations cannot be done simultaneously.**
 
         ## Add roles
-        A user may add `consumer` and `delegate` roles to their user profile. **The `provider` role cannot be added**. 
+        A user may add `consumer`, `delegate` and `trustee` roles to their user profile. **The `provider` role cannot be added**. 
 
         ## Regenerate client secret
         A user may regenerate a client secret corresponding to a client ID in case they have lost the client secret or it has been compromised. A new client secret will be generated and sent as part of the output **and will not be shown again.** 
@@ -1315,12 +1322,13 @@ paths:
                       type: array
                       minItems: 1
                       uniqueItems: true
-                      maxItems: 2
+                      maxItems: 3
                       items:
                         type: string
                         enum:
                           - consumer
                           - delegate
+                          - trustee
                         minLength: 5
                         maxLength: 10
                     orgId:
@@ -1349,13 +1357,14 @@ paths:
                   roles:
                     - consumer
                     - delegate
+                    - trustee
                   orgId: 123e4567-e89b-12d3-a456-426614174000
               Regenerate client secret:
                 value:
                   clientId: 25b2c2d5-a7fc-47d0-89e4-8709a1560bfa
         description: |-
           - `orgId` is a valid organization ID obtain from the `GET /auth/v1/organizations` API
-          - **`orgId` is required for `delegate` roles**
+          - **`orgId` is required for `delegate` or `trustee` roles**
           - `clientId` is a valid client ID (belonging to the user) whose corresponding client secret needs to be generate
         required: true
       tags:

--- a/src/main/java/iudx/aaa/server/apiserver/Roles.java
+++ b/src/main/java/iudx/aaa/server/apiserver/Roles.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
  * Enum that defines all valid roles recognized by the AAA server.
  */
 public enum Roles {
-  PROVIDER, DELEGATE, CONSUMER, ADMIN;
+  PROVIDER, DELEGATE, TRUSTEE, CONSUMER, ADMIN;
 
   static List<String> rolesAsStrings =
       Arrays.stream(Roles.values()).map(r -> r.name()).collect(Collectors.toList());

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -117,7 +117,6 @@ public class RegistrationServiceImpl implements RegistrationService {
   public static String AUTH_SERVER_URL = "";
   public static List<String> SERVERS_OMITTED_FROM_TOKEN_REVOKE = new ArrayList<String>();
 
-  /* TODO: include token service here */
   public RegistrationServiceImpl(PgPool pool, KcAdmin kc, TokenService tokenService,
       JsonObject options) {
     this.pool = pool;
@@ -138,7 +137,8 @@ public class RegistrationServiceImpl implements RegistrationService {
     UUID orgId = UUID.fromString(request.getOrgId());
     final String phone = request.getPhone();
 
-    if (requestedRoles.contains(Roles.PROVIDER) || requestedRoles.contains(Roles.DELEGATE)) {
+    if (requestedRoles.contains(Roles.PROVIDER) || requestedRoles.contains(Roles.DELEGATE)
+        || requestedRoles.contains(Roles.TRUSTEE)) {
       if (orgId.toString().equals(NIL_UUID)) {
         Response r = new ResponseBuilder().status(400).type(URN_MISSING_INFO)
             .title(ERR_TITLE_ORG_ID_REQUIRED).detail(ERR_DETAIL_ORG_ID_REQUIRED).build();
@@ -166,7 +166,8 @@ public class RegistrationServiceImpl implements RegistrationService {
     Future<String> checkOrgExist;
     String orgIdToSet;
 
-    if (roles.containsKey(Roles.PROVIDER) || roles.containsKey(Roles.DELEGATE)) {
+    if (roles.containsKey(Roles.PROVIDER) || roles.containsKey(Roles.DELEGATE)
+        || roles.containsKey(Roles.TRUSTEE)) {
       orgIdToSet = request.getOrgId();
       checkOrgExist = pool.withConnection(
           conn -> conn.preparedQuery(SQL_GET_ORG_DETAILS).execute(Tuple.of(orgId.toString())).map(
@@ -622,8 +623,11 @@ public class RegistrationServiceImpl implements RegistrationService {
     Future<String> email = kc.getEmailId(user.getKeycloakId());
     Future<String> checkOrgRequired;
 
-    /* orgId is needed always for delegate reg, even if the user has registered for provider role */
-    if (requestedRoles.contains(Roles.DELEGATE)) {
+    /*
+     * orgId is needed always for delegate or trustee reg, even if the user has registered for
+     * provider role
+     */
+    if (requestedRoles.contains(Roles.DELEGATE) || requestedRoles.contains(Roles.TRUSTEE)) {
       if (orgId.toString().equals(NIL_UUID)) {
         Response r = new ResponseBuilder().status(400).type(URN_MISSING_INFO)
             .title(ERR_TITLE_ORG_ID_REQUIRED).detail(ERR_DETAIL_ORG_ID_REQUIRED).build();

--- a/src/main/resources/db/migration/V2__Add_Trustee_To_Role_Enum.sql
+++ b/src/main/resources/db/migration/V2__Add_Trustee_To_Role_Enum.sql
@@ -1,0 +1,1 @@
+ALTER TYPE ${flyway:defaultSchema}.role_enum ADD VALUE 'TRUSTEE' AFTER 'DELEGATE';

--- a/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
@@ -222,6 +222,77 @@ public class UpdateUserTest {
   }
 
   @Test
+  @DisplayName("[Update roles] Test no org ID when delegate requesting trustee")
+  void delegateNoOrgId(VertxTestContext testContext) {
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("trustee"));
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.DELEGATE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.DELEGATE, RoleStatus.APPROVED);
+
+    Future<JsonObject> delegate =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), "", cons, false);
+
+    delegate.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(400, response.getInteger("status"));
+            assertEquals(ERR_TITLE_ORG_ID_REQUIRED, response.getString("title"));
+            assertEquals(URN_MISSING_INFO.toString(), response.getString("type"));
+            assertEquals(ERR_DETAIL_ORG_ID_REQUIRED, response.getString("detail"));
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
+  @DisplayName("[Update roles] Test invalid org Id when delegate getting trustee")
+  void delegateInvalidOrg(VertxTestContext testContext) {
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("trustee")).put("orgId",
+        UUID.randomUUID().toString());
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.DELEGATE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.DELEGATE, RoleStatus.APPROVED);
+
+    Future<JsonObject> consumer =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), "", cons, false);
+
+    consumer.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(400, response.getInteger("status"));
+            assertEquals(ERR_TITLE_ORG_NO_EXIST, response.getString("title"));
+            assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
+            assertEquals(ERR_DETAIL_ORG_NO_EXIST, response.getString("detail"));
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
   @DisplayName("[Update roles] Test no org ID when consumer requesting delegate")
   void consumerNoOrgId(VertxTestContext testContext) {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate"));
@@ -256,7 +327,7 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("[Update roles] Test invalid org Id when getting delegate")
+  @DisplayName("[Update roles] Test invalid org Id when consumer getting delegate")
   void consumerInvalidOrg(VertxTestContext testContext) {
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
         UUID.randomUUID().toString());
@@ -311,8 +382,7 @@ public class UpdateUserTest {
           .userId(userJson.getString("userId")).roles(roles)
           .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
 
-      Mockito.when(kc.getEmailId(any()))
-          .thenReturn(Future.succeededFuture(""));
+      Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(""));
 
       registrationService.updateUser(request, user,
           testContext.succeeding(response -> testContext.verify(() -> {
@@ -326,11 +396,11 @@ public class UpdateUserTest {
   }
 
   @Test
-  @DisplayName("[Update roles] Test consumer with gmail email cannot become delegate")
+  @DisplayName("[Update roles] Test consumer with gmail email cannot become delegate, trustee")
   void consumerDomainMismatch(VertxTestContext testContext) {
 
-    JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
-        orgIdFut.result().toString());
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate").add("trustee"))
+        .put("orgId", orgIdFut.result().toString());
 
     UpdateProfileRequest request = new UpdateProfileRequest(req);
 
@@ -426,6 +496,131 @@ public class UpdateUserTest {
   }
 
   @Test
+  @DisplayName("[Update roles] Test trustee get delegate role (orgId needed)")
+  void trusteeAddDele(VertxTestContext testContext) {
+
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("delegate")).put("orgId",
+        orgIdFut.result().toString());
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.TRUSTEE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.TRUSTEE, RoleStatus.APPROVED);
+
+    Future<JsonObject> trustee =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), url, cons, false);
+
+    trustee.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+      Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(200, response.getInteger("status"));
+            assertEquals(SUCC_TITLE_UPDATED_USER_ROLES, response.getString("title"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
+
+            JsonObject result = response.getJsonObject("results");
+
+            JsonObject name = result.getJsonObject("name");
+            assertEquals(name.getString("firstName"), userJson.getString("firstName"));
+            assertEquals(name.getString("lastName"), userJson.getString("lastName"));
+
+            @SuppressWarnings("unchecked")
+            List<String> returnedRoles = result.getJsonArray("roles").getList();
+            List<String> rolesString =
+                List.of(Roles.TRUSTEE.name().toLowerCase(), Roles.DELEGATE.name().toLowerCase());
+            assertTrue(
+                returnedRoles.containsAll(rolesString) && rolesString.containsAll(returnedRoles));
+
+            JsonArray clients = result.getJsonArray(RESP_CLIENT_ARR);
+            JsonObject defaultClient = clients.getJsonObject(0);
+            assertTrue(clients.size() > 0);
+            assertEquals(defaultClient.getString(RESP_CLIENT_ID), userJson.getString("clientId"));
+
+            JsonObject org = result.getJsonObject(RESP_ORG);
+            assertEquals(org.getString("url"), userJson.getString("url"));
+
+            assertEquals(result.getString(RESP_EMAIL), userJson.getString("email"));
+            assertEquals(result.getString("userId"), userJson.getString("userId"));
+            assertEquals(result.getString("keycloakId"), userJson.getString("keycloakId"));
+
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
+  @DisplayName("[Update roles] Test trustee get consumer role")
+  void trusteeAddCons(VertxTestContext testContext) {
+
+    JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer"));;
+
+    UpdateProfileRequest request = new UpdateProfileRequest(req);
+
+    List<Roles> roles = List.of(Roles.TRUSTEE);
+    Map<Roles, RoleStatus> cons = new HashMap<Roles, RoleStatus>();
+    cons.put(Roles.TRUSTEE, RoleStatus.APPROVED);
+
+    Future<JsonObject> trustee =
+        Utils.createFakeUser(pool, orgIdFut.result().toString(), url, cons, false);
+
+    trustee.onSuccess(userJson -> {
+      createdUsers.add(userJson);
+
+      User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+          .userId(userJson.getString("userId")).roles(roles)
+          .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+      Mockito.when(kc.getEmailId(any()))
+          .thenReturn(Future.succeededFuture(userJson.getString("email")));
+      Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
+
+      registrationService.updateUser(request, user,
+          testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(200, response.getInteger("status"));
+            assertEquals(SUCC_TITLE_UPDATED_USER_ROLES, response.getString("title"));
+            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
+
+            JsonObject result = response.getJsonObject("results");
+
+            JsonObject name = result.getJsonObject("name");
+            assertEquals(name.getString("firstName"), userJson.getString("firstName"));
+            assertEquals(name.getString("lastName"), userJson.getString("lastName"));
+
+            @SuppressWarnings("unchecked")
+            List<String> returnedRoles = result.getJsonArray("roles").getList();
+            List<String> rolesString =
+                List.of(Roles.TRUSTEE.name().toLowerCase(), Roles.CONSUMER.name().toLowerCase());
+            assertTrue(
+                returnedRoles.containsAll(rolesString) && rolesString.containsAll(returnedRoles));
+
+            JsonArray clients = result.getJsonArray(RESP_CLIENT_ARR);
+            JsonObject defaultClient = clients.getJsonObject(0);
+            assertTrue(clients.size() > 0);
+            assertEquals(defaultClient.getString(RESP_CLIENT_ID), userJson.getString("clientId"));
+
+            JsonObject org = result.getJsonObject(RESP_ORG);
+            assertEquals(org.getString("url"), userJson.getString("url"));
+
+            assertEquals(result.getString(RESP_EMAIL), userJson.getString("email"));
+            assertEquals(result.getString("userId"), userJson.getString("userId"));
+            assertEquals(result.getString("keycloakId"), userJson.getString("keycloakId"));
+
+            testContext.completeNow();
+          })));
+    });
+  }
+
+  @Test
   @DisplayName("[Update roles] Test existing role request")
   void existingRoles(VertxTestContext testContext) {
 
@@ -469,7 +664,7 @@ public class UpdateUserTest {
 
   @Test
   @DisplayName("[Update roles] Test pending provider getting consumer and delegate roles - with and without orgId")
-  void providerGettingConsDele(VertxTestContext testContext) {
+  void providerGettingConsTrustee(VertxTestContext testContext) {
 
     JsonObject req = new JsonObject().put("roles", new JsonArray().add("consumer").add("delegate"));
 
@@ -509,8 +704,6 @@ public class UpdateUserTest {
             assertEquals(URN_MISSING_INFO.toString(), resp.getString("type"));
             assertEquals(ERR_DETAIL_ORG_ID_REQUIRED, resp.getString("detail"));
             noOrgIdFail.flag();
-
-
 
             registrationService.updateUser(correctRequest, user,
                 testContext.succeeding(response -> testContext.verify(() -> {
@@ -825,7 +1018,7 @@ public class UpdateUserTest {
 
     consumer.onSuccess(userJson -> {
       createdUsers.add(userJson);
-      
+
       Mockito.when(kc.getEmailId(any()))
           .thenReturn(Future.succeededFuture(userJson.getString("email")));
 

--- a/src/test/resources/Integration_Test.postman_collection.json
+++ b/src/test/resources/Integration_Test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "83504fab-3f10-448e-9f43-adbb1c4787c4",
+		"_postman_id": "2aecbac2-f440-4569-a625-59689b7d2fc4",
 		"name": "Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -988,6 +988,65 @@
 					"response": []
 				},
 				{
+					"name": "orgId needed for trustee role - [400]",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:MissingInformation\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"roles\": [\n        \"trustee\"\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "orgId needed for provider role - [400] Copy",
 					"event": [
 						{
@@ -1260,7 +1319,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"roles\":[\"provider\"],\n    \"orgId\":\"{{$randomUUID}}\"\n}",
+							"raw": "{\n    \"roles\":[\"provider\", \"trustee\"],\n    \"orgId\":\"{{$randomUUID}}\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1364,7 +1423,7 @@
 					"response": []
 				},
 				{
-					"name": "Successful delegate and provider registration registration - [201] (All roles)",
+					"name": "Successful delegate, trustee and provider registration registration - [201] (All roles)",
 					"event": [
 						{
 							"listen": "test",
@@ -1390,7 +1449,7 @@
 									"    pm.expect(result).to.have.property(\"name\");",
 									"    pm.expect(result).to.have.property(\"keycloakId\");",
 									"    pm.expect(result).to.have.property(\"clients\");",
-									"    pm.expect(result.roles).to.have.members([\"delegate\"]);",
+									"    pm.expect(result.roles).to.have.members([\"delegate\", \"trustee\"]);",
 									"",
 									"    const clients = result.clients;",
 									"    pm.expect(clients).length.greaterThan(0);",
@@ -1419,7 +1478,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"roles\": [\n        \"delegate\",\n        \"provider\"\n    ],\n    \"orgId\": \"3a054e6a-220d-4d49-8cbd-25447dfaa8ed\",\n    \"phone\": \"9989989981\"\n}",
+							"raw": "{\n    \"roles\": [\n        \"delegate\",\n        \"provider\",\n        \"trustee\"\n    ],\n    \"orgId\": \"3a054e6a-220d-4d49-8cbd-25447dfaa8ed\",\n    \"phone\": \"9989989981\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4793,7 +4852,7 @@
 									"    pm.expect(result).to.have.property(\"name\");",
 									"    pm.expect(result).to.have.property(\"keycloakId\");",
 									"    pm.expect(result).to.have.property(\"clients\");",
-									"    pm.expect(result.roles).to.have.members([\"delegate\", \"consumer\", \"provider\"]);",
+									"    pm.expect(result.roles).to.have.members([\"delegate\", \"consumer\", \"provider\", \"trustee\"]);",
 									"",
 									"    const clients = result.clients;",
 									"    pm.expect(clients).length.greaterThan(0);",
@@ -4938,7 +4997,64 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"roles\":[\"delegate\"]}",
+							"raw": "{\n    \"roles\": [\n        \"delegate\"\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "orgId required for trustee role  - [400]",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:MissingInformation\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"roles\": [\n        \"trustee\"\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5072,7 +5188,80 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"roles\":[\"delegate\"],\n \"orgId\": \"3a054e6a-220d-4d49-8cbd-25447dfaa8ed\"}",
+							"raw": "{\n    \"roles\": [\n        \"delegate\"\n    ],\n    \"orgId\": \"3a054e6a-220d-4d49-8cbd-25447dfaa8ed\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add trustee role for rejected provider  - [200]",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
+									"    const result = body.results;",
+									"",
+									"    pm.expect(result).to.have.property(\"userId\");",
+									"    pm.expect(result).to.have.property(\"email\");",
+									"    pm.expect(result).to.have.property(\"name\");",
+									"    pm.expect(result).to.have.property(\"keycloakId\");",
+									"    pm.expect(result).to.have.property(\"clients\");",
+									"    pm.expect(result.roles).to.have.members([\"delegate\", \"trustee\"]);",
+									"",
+									"    const clients = result.clients;",
+									"    pm.expect(clients).length.greaterThan(0);",
+									"    pm.expect(clients[0]).to.have.property(\"clientId\");",
+									"    pm.expect(clients[0]).to.not.have.property(\"clientSecret\");",
+									"    pm.expect(clients[0]).to.have.property(\"clientName\");",
+									"",
+									"    pm.expect(result).to.have.property(\"organization\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"roles\": [\n        \"trustee\"\n    ],\n    \"orgId\": \"3a054e6a-220d-4d49-8cbd-25447dfaa8ed\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5894,7 +6083,7 @@
 									"    pm.expect(result).to.have.property(\"name\");",
 									"    pm.expect(result).to.have.property(\"keycloakId\");",
 									"    pm.expect(result).to.have.property(\"clients\");",
-									"    pm.expect(result.roles).to.have.members([\"consumer\",\"delegate\",\"provider\"]);",
+									"    pm.expect(result.roles).to.have.members([\"consumer\",\"delegate\",\"provider\", \"trustee\"]);",
 									"",
 									"    const clients = result.clients;",
 									"    pm.expect(clients).length.greaterThan(0);",
@@ -6002,7 +6191,7 @@
 					"response": []
 				},
 				{
-					"name": "List User rejected provider, delegate",
+					"name": "List User rejected provider, delegate, trustee",
 					"event": [
 						{
 							"listen": "test",
@@ -6028,7 +6217,7 @@
 									"    pm.expect(result).to.have.property(\"name\");",
 									"    pm.expect(result).to.have.property(\"keycloakId\");",
 									"    pm.expect(result).to.have.property(\"clients\");",
-									"    pm.expect(result.roles).to.have.members([\"delegate\"]);",
+									"    pm.expect(result.roles).to.have.members([\"delegate\", \"trustee\"]);",
 									"",
 									"    const clients = result.clients;",
 									"    pm.expect(clients).length.greaterThan(0);",


### PR DESCRIPTION
- Add 'trustee' to Roles enum
- Update POST, PUT /user/profile to include trustee role
- Add SQL migration for adding 'TRUSTEE' to Roles type in DB
- Update OpenAPI spec and docs
- Added unit, integ tests for create, update user profile for trustee


 