### PR TITLE
Add migration for APD policies table and adding 'APD' to item enum

### DIFF
--- a/src/main/resources/db/migration/V4__Add_Apd_policy_table_and_Add_APD_to_resource_enum.sql
+++ b/src/main/resources/db/migration/V4__Add_Apd_policy_table_and_Add_APD_to_resource_enum.sql
@@ -1,0 +1,32 @@
+-- Adding apd_policies table
+
+CREATE TABLE apd_policies (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    apd_id uuid NOT NULL,
+    user_class character varying NOT NULL,
+    item_id uuid NOT NULL,
+    item_type item_enum NOT NULL,
+    owner_id uuid NOT NULL,
+    status policy_status_enum NOT NULL,
+    expiry_time timestamp without time zone NOT NULL,
+    constraints jsonb NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+ALTER TABLE apd_policies OWNER TO ${flyway:user};
+
+ALTER TABLE ONLY apd_policies
+    ADD CONSTRAINT apd_policies_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY apd_policies
+    ADD CONSTRAINT apd_policies_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);
+
+ALTER TABLE ONLY apd_policies
+    ADD CONSTRAINT apd_policies_apd_id_fkey FOREIGN KEY (apd_id) REFERENCES apds(id);
+
+GRANT SELECT,INSERT,UPDATE ON TABLE apd_policies TO ${authUser};
+
+-- Update resource_enum with apd type
+
+ALTER TYPE item_enum ADD VALUE 'APD' AFTER 'RESOURCE';


### PR DESCRIPTION
- APD policies table is similar to policies table; instead of `user_id`, we
have `apd_id` (foreign key to APDs table) and `user_class`
- Updated item_enum to include 'APD' - used when trustees set policies
for providers to permit them to write policies using their APDs