### PR TITLE
Add delete APD policy functionality to DELETE /policies API

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -36,6 +36,8 @@ public class Constants {
   public static final String CONSUMER_ROLE = "CONSUMER";
   public static final String PROVIDER_ROLE = "PROVIDER";
   public static final String DELEGATE_ROLE = "DELEGATE";
+  public static final String USR_POL = "USER";
+  public static final String APD_POL = "APD";
 
 
   public static final String RESULTS = "results";
@@ -173,9 +175,16 @@ public class Constants {
           + "where  a.item_type = $2::item_enum  "
           + "AND a.status = $3::policy_status_enum  AND a.expiry_time > NOW() And  a.owner_id = $1::UUID";
 
-  public static final String CHECK_POLICY_EXIST =
-      "select id,owner_id,item_type from policies"
-          + " where status = $1::policy_status_enum  and id = any($2::uuid[])";
+  public static final String EXISTING_ACTIVE_USR_POL =
+      "SELECT id FROM policies WHERE owner_id = $1::uuid AND status = 'ACTIVE' AND id = ANY($2::uuid[]) ";
+
+  public static final String EXISTING_ACTIVE_USR_POL_NO_RES_SER =
+      "SELECT id FROM policies WHERE owner_id = $1::uuid AND status = 'ACTIVE'"
+      + " AND id = ANY($2::uuid[]) AND item_type != 'RESOURCE_SERVER'";
+
+  public static final String EXISTING_ACTIVE_APD_POL =
+      "SELECT id FROM apd_policies WHERE owner_id = $1::uuid AND status = 'ACTIVE' AND id = ANY($2::uuid[]) ";
+
   public static final String RES_OWNER_CHECK =
       "select id from policies where owner_id = $1::uuid "
           + "and status = $2::policy_status_enum and id = any($3::uuid[]) and expiry_time > now()";
@@ -191,10 +200,12 @@ public class Constants {
           + "where  a.user_id = $1::UUID and item_type = $2::item_enum "
           + "and a.owner_id = b.owner_id and b.url = $3::varchar "
           + "and a.status = $4::policy_status_enum and a.expiry_time > now()";
-  public static final String DELETE_POLICY =
-      "update policies set status = $1::policy_status_enum , updated_at = now()"
-          + " where status = $2::policy_status_enum and expiry_time > now() "
-          + " and id = any($3::uuid[])";
+
+  public static final String DELETE_USR_POLICY =
+"UPDATE policies SET status = 'DELETED', updated_at = NOW() WHERE id = ANY($1::uuid[])";
+
+  public static final String DELETE_APD_POLICY =
+"UPDATE apd_policies SET status = 'DELETED', updated_at = NOW() WHERE id = ANY($1::uuid[])";
   // create policy
 
   public static final String CHECKUSEREXIST = "select id from users where id = any($1::uuid[])";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -441,118 +441,51 @@ public class PolicyServiceImpl implements PolicyService {
   }
 
   @Override
-  public PolicyService deletePolicy(
-      JsonArray request, User user,JsonObject data, Handler<AsyncResult<JsonObject>> handler) {
-      LOGGER.debug("Info : " + LOGGER.getName() + " : Request received");
-      boolean isDelegate = !data.isEmpty();
-      // check if all req items exist to delete;
-      if (user.getUserId().equals(NIL_UUID)) {
-          // empty user object
-          Response r =
-                  new Response.ResponseBuilder()
-                          .type(URN_MISSING_INFO)
-                          .title(String.valueOf(URN_MISSING_INFO))
-                          .detail(NO_USER)
-                          .status(401)
-                          .build();
-          handler.handle(Future.succeededFuture(r.toJson()));
-          return this;
-      }
-
-      List<Roles> roles = user.getRoles();
-
-      if (!roles.contains(Roles.ADMIN)
-              && !roles.contains(Roles.PROVIDER)
-              && !roles.contains(Roles.DELEGATE)) {
-          // 403 not allowed to create policy
-          Response r =
-                  new Response.ResponseBuilder()
-                          .type(URN_INVALID_ROLE)
-                          .title(INVALID_ROLE)
-                          .detail(INVALID_ROLE)
-                          .status(401)
-                          .build();
-          handler.handle(Future.succeededFuture(r.toJson()));
-          return this;
-      }
-
-      List<UUID> req =
-              request.stream()
-                      .map(JsonObject.class::cast)
-                      .filter(tagObject -> !tagObject.getString(ID).isEmpty())
-                      .map(tagObject -> UUID.fromString(tagObject.getString(ID)))
-                      .collect(Collectors.toList());
-      // map of policy to object with policy details
-      Future<Map<UUID, JsonObject>> policyDetails = deletePolicy.checkPolicyExist(req);
-
-     Future<Void> ownerCheck = policyDetails
-              .compose(
-                      checkSuc -> {
-                          List<UUID> ownerIds =
-                                  checkSuc.values().stream()
-                                          .map(map -> UUID.fromString(map.getString(OWNERID)))
-                                          .filter(x -> !x.equals(UUID.fromString(user.getUserId())))
-                                          .distinct()
-                                          .collect(Collectors.toList());
-
-                          if (!ownerIds.isEmpty()) {
-                              if (isDelegate) {
-                                  // not resource server type
-                                  List<UUID> ids =
-                                          checkSuc.values().stream()
-                                                  .filter(x -> !x.getString(ITEMTYPE)
-                                                          .equalsIgnoreCase(RESOURCE_SERVER_TABLE.toUpperCase()))
-                                                  .map(map -> UUID.fromString(map.getString(OWNERID)))
-                                                  .filter(x -> !x.equals(UUID.fromString(data.getString("providerId"))))
-                                                  .distinct()
-                                                  .collect(Collectors.toList());
-                                  if (!ids.isEmpty()) {
-                                      Response r =
-                                              new Response.ResponseBuilder()
-                                                      .type(URN_INVALID_INPUT)
-                                                      .title(ID_NOT_PRESENT)
-                                                      .detail(ID_NOT_PRESENT)
-                                                      .status(400)
-                                                      .build();
-                                      return Future.failedFuture(new ComposeException(r));
-                                  }
-                                  return Future.succeededFuture();
-                              } else {
-                                  Response r =
-                                          new Response.ResponseBuilder()
-                                                  .type(URN_INVALID_INPUT)
-                                                  .title(ID_NOT_PRESENT)
-                                                  .detail(ID_NOT_PRESENT)
-                                                  .status(400)
-                                                  .build();
-                                  return Future.failedFuture(new ComposeException(r));
-                              }
-                          }
-                          return Future.succeededFuture();
-                      });
-
-      ownerCheck.compose( succ ->
-              deletePolicy
-                      .delPolicy(req)
-                      .onSuccess(
-                              resp -> {
-                                  Response r =
-                                          new Response.ResponseBuilder()
-                                                  .type(URN_SUCCESS)
-                                                  .title(SUCC_TITLE_POLICY_DEL)
-                                                  .status(200)
-                                                  .build();
-                                  handler.handle(Future.succeededFuture(r.toJson()));
-                              }))
-              .onFailure(
-                      obj -> {
-                          LOGGER.error(obj.getMessage());
-                          if (obj instanceof ComposeException) {
-                              ComposeException e = (ComposeException) obj;
-                              handler.handle(Future.succeededFuture(e.getResponse().toJson()));
-                          } else handler.handle(Future.failedFuture(INTERNALERROR));
-                      });
+  public PolicyService deletePolicy(JsonArray request, User user, JsonObject data,
+      Handler<AsyncResult<JsonObject>> handler) {
+    LOGGER.debug("Info : " + LOGGER.getName() + " : Request received");
+    boolean isDelegate = !data.isEmpty();
+    // check if all req items exist to delete;
+    if (user.getUserId().equals(NIL_UUID)) {
+      // empty user object
+      Response r = new Response.ResponseBuilder().type(URN_MISSING_INFO)
+          .title(String.valueOf(URN_MISSING_INFO)).detail(NO_USER).status(401).build();
+      handler.handle(Future.succeededFuture(r.toJson()));
       return this;
+    }
+
+    List<Roles> roles = user.getRoles();
+
+    if (!roles.contains(Roles.ADMIN) && !roles.contains(Roles.PROVIDER)
+        && !roles.contains(Roles.DELEGATE)) {
+      // 403 not allowed to create policy
+      Response r = new Response.ResponseBuilder().type(URN_INVALID_ROLE).title(INVALID_ROLE)
+          .detail(INVALID_ROLE).status(401).build();
+      handler.handle(Future.succeededFuture(r.toJson()));
+      return this;
+    }
+
+    List<UUID> req = request.stream().map(JsonObject.class::cast)
+        .filter(tagObject -> !tagObject.getString(ID).isEmpty())
+        .map(tagObject -> UUID.fromString(tagObject.getString(ID))).collect(Collectors.toList());
+
+    // map of policy to object with policy details
+    Future<Map<String, List<UUID>>> policyIds = deletePolicy.checkPolicyExist(req, user, data);
+
+    policyIds.compose(map -> deletePolicy.delPolicy(map)).onSuccess(resp -> {
+
+      Response r = new Response.ResponseBuilder().type(URN_SUCCESS).title(SUCC_TITLE_POLICY_DEL)
+          .status(200).build();
+      handler.handle(Future.succeededFuture(r.toJson()));
+    }).onFailure(obj -> {
+      LOGGER.error(obj.getMessage());
+      if (obj instanceof ComposeException) {
+        ComposeException e = (ComposeException) obj;
+        handler.handle(Future.succeededFuture(e.getResponse().toJson()));
+      } else
+        handler.handle(Future.failedFuture(INTERNALERROR));
+    });
+    return this;
   }
 
   @Override

--- a/src/test/java/iudx/aaa/server/policy/TestRequest.java
+++ b/src/test/java/iudx/aaa/server/policy/TestRequest.java
@@ -165,12 +165,23 @@ public class TestRequest {
   public static JsonArray succDelReq = new JsonArray().add(obj4);
 
 
-  public static String INSERT_REQ =
-          "insert into test.policies "
-                  + "(user_id,item_id,item_type,owner_id,status,expiry_time,constraints,created_at,updated_at) "
-                  + "values('d1262b13-1cbe-4b66-a9b2-96df86437683','66ff82fb-1720-415d-a2f3-18ff65c0e050','RESOURCE', "
-                  + " '844e251b-574b-46e6-9247-f76f1f70a637','ACTIVE','2023-06-15 09:07:16.034289','{}', NOW(), NOW()) returning id";
+  public static String INSERT_USER_POL =
+      "insert into policies "
+          + "(id, user_id,item_id,item_type,owner_id,status,expiry_time,constraints,created_at,updated_at) "
+          + "values($1::uuid, 'd1262b13-1cbe-4b66-a9b2-96df86437683','66ff82fb-1720-415d-a2f3-18ff65c0e050','RESOURCE', "
+          + " '844e251b-574b-46e6-9247-f76f1f70a637','ACTIVE','2023-06-15 09:07:16.034289','{}', NOW(), NOW())";
 
+  public static String INSERT_EXPIRED_USER_POL =
+      "insert into policies "
+          + "(id, user_id,item_id,item_type,owner_id,status,expiry_time,constraints,created_at,updated_at) "
+          + "values($1::uuid, 'd1262b13-1cbe-4b66-a9b2-96df86437683','66ff82fb-1720-415d-a2f3-18ff65c0e050','RESOURCE', "
+          + " '844e251b-574b-46e6-9247-f76f1f70a637','ACTIVE','1998-06-15 09:07:16.034289','{}', NOW(), NOW())";
+
+  public static String INSERT_APD_POL =
+      "insert into apd_policies "
+          + "(id, apd_id, user_class,item_id,item_type,owner_id,status,expiry_time,constraints,created_at,updated_at) "
+          + "values($1::uuid, '88b7bdbc-936c-4478-8059-f95f4c8a6352','unitTest','66ff82fb-1720-415d-a2f3-18ff65c0e050','RESOURCE', "
+          + " '844e251b-574b-46e6-9247-f76f1f70a637','ACTIVE','2023-06-15 09:07:16.034289','{}', NOW(), NOW())";
 
   // create policy
   public static User consumerUser =


### PR DESCRIPTION
In `DeletePolicyTest`.
- Added ordering for unit tests so that deleted policies can be used in further tests
- Added test to see if expired policy can be deleted successfully