### PR TITLE
Updated list policy API to include listing APD-related policies

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -26,12 +26,14 @@ public class Constants {
   public static final String RES = "res";
   public static final String USER_ID = "user_id";
   public static final String ITEM_ID = "item_id";
+  public static final String APD_ID = "apd_id";
   public static final String ITEM_TYPE = "item_type";
   public static final String EXPIRY_TIME = "expiry_time";
   public static final String OWNER_ID = "owner_id";
   public static final String RESOURCE_GROUP_TABLE = "resource_group";
   public static final String RESOURCE_TABLE = "resource";
   public static final String CAT_ID = "cat_id";
+  public static final String APD_DETAILS = "apd";
   public static final String OWNER_DETAILS = "owner";
   public static final String USER_DETAILS = "user";
   public static final String CONSUMER_ROLE = "CONSUMER";
@@ -161,20 +163,6 @@ public class Constants {
           + "status = $4::policy_status_enum "
           + " and expiry_time > now()";
   // List Policy queries
-  public static final String GET_POLICIES =
-      "Select a.id as  \"policyId\", a.user_id, a.owner_id ,a.item_type as \"itemType\" ,"
-          + " a.expiry_time as \"expiryTime\" ,a.constraints, b.cat_id  as \"itemId\" from policies a INNER JOIN ";
-  public static final String GET_SERVER_POLICIES =
-      "Select a.id as  \"policyId\", a.user_id, a.owner_id ,a.item_type as \"itemType\" ,"
-          + " a.expiry_time as \"expiryTime\" ,a.constraints, b.url  as \"itemId\" from policies a INNER JOIN ";
-  public static final String GET_POLICIES_JOIN =
-      " b on a.item_id = b.id "
-          + "where  a.item_type = $2::item_enum  "
-          + "AND a.status = $3::policy_status_enum  AND a.expiry_time > NOW() And (a.owner_id = $1::UUID or  a.user_id = $1::UUID)";
-  public static final String GET_POLICIES_JOIN_DELEGATE =
-      " b on a.item_id = b.id "
-          + "where  a.item_type = $2::item_enum  "
-          + "AND a.status = $3::policy_status_enum  AND a.expiry_time > NOW() And  a.owner_id = $1::UUID";
 
   public static final String EXISTING_ACTIVE_USR_POL =
       "SELECT id FROM policies WHERE owner_id = $1::uuid AND status = 'ACTIVE' AND id = ANY($2::uuid[]) ";
@@ -185,6 +173,25 @@ public class Constants {
 
   public static final String EXISTING_ACTIVE_APD_POL =
       "SELECT id FROM apd_policies WHERE owner_id = $1::uuid AND status = 'ACTIVE' AND id = ANY($2::uuid[]) ";
+
+  public static final String GET_USER_POLICIES_AUTH_DELEGATE =
+      "SELECT id AS \"policyId\", user_id, owner_id, item_id, item_type AS \"itemType\","
+          + " expiry_time AS \"expiryTime\", constraints FROM policies WHERE status = 'ACTIVE'"
+          + " AND owner_id = $1::uuid";
+  
+  public static final String GET_USER_POLICIES =
+      "SELECT id AS \"policyId\", user_id, owner_id, item_id, item_type AS \"itemType\","
+          + " expiry_time AS \"expiryTime\", constraints FROM policies WHERE status = 'ACTIVE'"
+          + " AND (owner_id = $1::uuid OR user_id = $1::uuid)";
+  
+  public static final String GET_APD_POLICIES =
+      "SELECT id AS \"policyId\", apd_id, user_class AS \"userClass\", owner_id, item_id,"
+      + " item_type AS \"itemType\", expiry_time AS \"expiryTime\", constraints FROM apd_policies "
+          + "WHERE status = 'ACTIVE' AND owner_id = $1::uuid";
+  
+  public static final String CHECK_POLICY_EXIST =
+      "select id,owner_id,item_type from policies"
+          + " where status = $1::policy_status_enum  and id = any($2::uuid[])";
 
   public static final String RES_OWNER_CHECK =
       "select id from policies where owner_id = $1::uuid "
@@ -231,6 +238,15 @@ public class Constants {
 
   public static final String GET_RES_SER_ID =
       "select url,id from resource_server where url = any($1::text[])";
+
+  public static final String GET_RES_GRP_CAT_IDS =
+      "SELECT id, cat_id FROM resource_group WHERE id = ANY($1::uuid[]) ";
+
+  public static final String GET_RES_CAT_IDS =
+      "SELECT id, cat_id FROM resource WHERE id = ANY($1::uuid[]) ";
+
+  public static final String GET_RES_SER_URLS =
+      "SELECT url, id FROM resource_server WHERE id = ANY($1::uuid[])";
 
   public static final String GET_PROVIDER_ID =
       "select email_hash,id from users where email_hash = any($1::text[])";
@@ -364,7 +380,8 @@ public class Constants {
   public enum itemTypes {
     RESOURCE_SERVER("RESOURCE_SERVER"),
     RESOURCE_GROUP("RESOURCE_GROUP"),
-    RESOURCE("RESOURCE");
+    RESOURCE("RESOURCE"),
+    APD("APD");
 
     private final String type;
 

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -3,6 +3,7 @@ package iudx.aaa.server.policy;
 public class Constants {
 
   public static final String REGISTRATION_SERVICE_ADDRESS = "iudx.aaa.registration.service";
+  public static final String APD_SERVICE_ADDRESS = "iudx.aaa.apd.service";
   public static final String POLICY_SERVICE_ADDRESS = "iudx.aaa.policy.service";
   // db columns
   public static final String USERID = "userId";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -13,6 +13,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.apiserver.CreateDelegationRequest;
 import iudx.aaa.server.apiserver.CreatePolicyNotification;
 import iudx.aaa.server.apiserver.CreatePolicyRequest;
@@ -161,6 +162,7 @@ public class PolicyServiceImpl implements PolicyService {
   private static final Logger LOGGER = LogManager.getLogger(PolicyServiceImpl.class);
   private final PgPool pool;
   private final RegistrationService registrationService;
+  private final ApdService apdService;
   private final deletePolicy deletePolicy;
   private final createPolicy createPolicy;
   private final createDelegate createDelegate;
@@ -179,11 +181,13 @@ public class PolicyServiceImpl implements PolicyService {
   public PolicyServiceImpl(
       PgPool pool,
       RegistrationService registrationService,
+      ApdService apdService,
       CatalogueClient catalogueClient,
       JsonObject authOptions,
       JsonObject catServerOptions) {
     this.pool = pool;
     this.registrationService = registrationService;
+    this.apdService = apdService;
     this.catalogueClient = catalogueClient;
     this.authOptions = authOptions;
     this.catServerOptions = catServerOptions;

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -580,7 +580,7 @@ public class PolicyServiceImpl implements PolicyService {
 
           Promise<JsonObject> apdDetails = Promise.promise();
           if (!apdIds.isEmpty()) {
-            apdService.getApdDetails(apdIds, apdDetails);
+            apdService.getApdDetails(List.of(), apdIds, apdDetails);
           } else {
             apdDetails.complete(new JsonObject());
           }

--- a/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyVerticle.java
@@ -1,6 +1,7 @@
 package iudx.aaa.server.policy;
 
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.registration.RegistrationService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,6 +12,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.sqlclient.PoolOptions;
 
+import static iudx.aaa.server.policy.Constants.APD_SERVICE_ADDRESS;
 import static iudx.aaa.server.policy.Constants.POLICY_SERVICE_ADDRESS;
 import static iudx.aaa.server.policy.Constants.REGISTRATION_SERVICE_ADDRESS;
 
@@ -46,6 +48,7 @@ public class PolicyVerticle extends AbstractVerticle {
   private JsonObject catOptions;
   private PolicyService policyService;
   private RegistrationService registrationService;
+  private ApdService apdService;
   private CatalogueClient catalogueClient;
   private ServiceBinder binder;
   private MessageConsumer<JsonObject> consumer;
@@ -101,10 +104,12 @@ public class PolicyVerticle extends AbstractVerticle {
 
     /* Create the client pool */
 
-    PgPool pool = PgPool.pool(vertx,connectOptions, poolOptions);
+    PgPool pool = PgPool.pool(vertx, connectOptions, poolOptions);
     registrationService = RegistrationService.createProxy(vertx, REGISTRATION_SERVICE_ADDRESS);
-    catalogueClient = new CatalogueClient(vertx,pool,catalogueOptions);
-    policyService = new PolicyServiceImpl(pool,registrationService,catalogueClient,authOptions,catOptions);
+    apdService = ApdService.createProxy(vertx, APD_SERVICE_ADDRESS);
+    catalogueClient = new CatalogueClient(vertx, pool, catalogueOptions);
+    policyService = new PolicyServiceImpl(pool, registrationService, apdService, catalogueClient,
+        authOptions, catOptions);
 
     binder = new ServiceBinder(vertx);
     consumer =

--- a/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreateDelegationsTest.java
@@ -19,8 +19,10 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.registration.RegistrationService;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
@@ -43,6 +45,7 @@ public class CreateDelegationsTest {
     private static PgConnectOptions connectOptions;
     private static PolicyService policyService;
     private static RegistrationService registrationService;
+    private static ApdService apdService = Mockito.mock(ApdService.class);
     private static CatalogueClient catalogueClient;
     private static JsonObject authOptions;
     private static JsonObject catOptions;
@@ -99,7 +102,8 @@ public class CreateDelegationsTest {
 
         pgclient = PgPool.pool(vertx, connectOptions, poolOptions);
 
-        policyService = new PolicyServiceImpl(pgclient,registrationService,catalogueClient,authOptions,catOptions);
+        policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
+            catalogueClient, authOptions, catOptions);
         testContext.completeNow();
     }
 

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyTest.java
@@ -8,6 +8,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.apiserver.ResourceObj;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.util.ComposeException;
@@ -70,6 +71,7 @@ public class CreatePolicyTest {
   private static JsonObject authOptions;
   private static JsonObject catOptions;
   private static RegistrationService registrationService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
   private static MockRegistrationFactory mockRegistrationFactory;
   private static CatalogueClient catClient;
 
@@ -125,9 +127,8 @@ public class CreatePolicyTest {
                   catClient = Mockito.mock(CatalogueClient.class);
                   mockRegistrationFactory = new MockRegistrationFactory();
                   registrationService = mockRegistrationFactory.getInstance();
-                  policyService =
-                      new PolicyServiceImpl(
-                          pgclient, registrationService, catClient, authOptions, catOptions);
+                  policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
+                      catClient, authOptions, catOptions);
                   testContext.completeNow();
           ;
   }

--- a/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeleteDelegationTest.java
@@ -33,6 +33,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.apiserver.DeleteDelegationRequest;
 import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
@@ -82,6 +83,7 @@ public class DeleteDelegationTest {
   private static PoolOptions poolOptions;
   private static PgConnectOptions connectOptions;
   private static PolicyService policyService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
   private static RegistrationService registrationService;
   private static JsonObject catalogueOptions;
   private static JsonObject authOptions;
@@ -203,8 +205,8 @@ public class DeleteDelegationTest {
           .map(val -> val.value()).onSuccess(s -> {
             delegationId.complete(s);
             registrationService = mockRegistrationFactory.getInstance();
-            policyService = new PolicyServiceImpl(pool, registrationService, catalogueClient,
-                authOptions, catOptions);
+            policyService = new PolicyServiceImpl(pool, registrationService, apdService,
+                catalogueClient, authOptions, catOptions);
             testContext.completeNow();
           }));
     });

--- a/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
@@ -10,6 +10,7 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.registration.RegistrationService;
 import org.apache.logging.log4j.LogManager;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
@@ -66,6 +68,7 @@ public class DeletePolicyTest {
   private static PoolOptions poolOptions;
   private static PgConnectOptions connectOptions;
   private static PolicyService policyService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
   private static RegistrationService registrationService;
   private static CatalogueClient catalogueClient;
   private static Vertx vertxObj;

--- a/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeletePolicyTest.java
@@ -133,8 +133,8 @@ public class DeletePolicyTest {
             .compose(x -> conn.preparedQuery(INSERT_APD_POL).execute(Tuple.of(apdPolicyId)))
             .compose(x -> conn.preparedQuery(INSERT_EXPIRED_USER_POL).execute(Tuple.of(expiredUserPolicyId))))
         .onSuccess(obj -> {
-          policyService = new PolicyServiceImpl(pgclient, registrationService, catalogueClient,
-              authOptions, catOptions);
+          policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
+              catalogueClient, authOptions, catOptions);
           testContext.completeNow();
         }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListDelegationTest.java
@@ -31,6 +31,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
@@ -75,6 +76,7 @@ public class ListDelegationTest {
   private static PoolOptions poolOptions;
   private static PgConnectOptions connectOptions;
   private static PolicyService policyService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
   private static RegistrationService registrationService;
   private static JsonObject authOptions;
   private static JsonObject catOptions;
@@ -190,8 +192,9 @@ public class ListDelegationTest {
     }).onSuccess(r -> {
 
       registrationService = mockRegistrationFactory.getInstance();
-      policyService = new PolicyServiceImpl(pool, registrationService, catalogueClient, authOptions,
-          catOptions);
+      policyService =
+          new PolicyServiceImpl(
+              pool, registrationService,apdService, catalogueClient, authOptions, catOptions);
       testContext.completeNow();
     });
   }

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -137,15 +137,15 @@ public class ListPolicyTest {
     }).when(catalogueClient).getCatIds(any(), any());
 
     Mockito.doAnswer(i -> {
-      Promise<JsonObject> p = i.getArgument(1);
+      Promise<JsonObject> p = i.getArgument(2);
       JsonObject result = new JsonObject();
-      List<String> ids = i.getArgument(0);
+      List<String> ids = i.getArgument(1);
       for (String x : ids) {
-        result.put(x, new JsonObject());
+        result.put(x, new JsonObject().put(URL, "<apd-url-placeholder>"));
       }
       p.complete(result);
       return i.getMock();
-    }).when(apdService).getApdDetails(any(), any());
+    }).when(apdService).getApdDetails(any(), any(), any());
 
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(1);
@@ -180,15 +180,15 @@ public class ListPolicyTest {
     }).when(catalogueClient).getCatIds(any(), any());
 
     Mockito.doAnswer(i -> {
-      Promise<JsonObject> p = i.getArgument(1);
+      Promise<JsonObject> p = i.getArgument(2);
       JsonObject result = new JsonObject();
-      List<String> ids = i.getArgument(0);
+      List<String> ids = i.getArgument(1);
       for (String x : ids) {
-        result.put(x, new JsonObject());
+        result.put(x, new JsonObject().put(URL, "<apd-url-placeholder>"));
       }
       p.complete(result);
       return i.getMock();
-    }).when(apdService).getApdDetails(any(), any());
+    }).when(apdService).getApdDetails(any(), any(), any());
 
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(1);

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -20,8 +20,10 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.registration.RegistrationService;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
@@ -43,6 +45,7 @@ public class ListPolicyTest {
     private static PoolOptions poolOptions;
     private static PgConnectOptions connectOptions;
     private static PolicyService policyService;
+    private static ApdService apdService = Mockito.mock(ApdService.class);
     private static RegistrationService registrationService;
     private static CatalogueClient catalogueClient;
     private static JsonObject authOptions;
@@ -102,7 +105,8 @@ public class ListPolicyTest {
 
         mockRegistrationFactory = new MockRegistrationFactory();
         registrationService = mockRegistrationFactory.getInstance();
-        policyService = new PolicyServiceImpl(pgclient,registrationService,catalogueClient,authOptions,catOptions);
+        policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
+            catalogueClient, authOptions, catOptions);
         testContext.completeNow();
     }
 

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -5,12 +5,19 @@ import static iudx.aaa.server.apiserver.util.Urn.*;
 import static iudx.aaa.server.policy.Constants.*;
 import static iudx.aaa.server.policy.TestRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -28,143 +35,204 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
 public class ListPolicyTest {
-    private static Logger LOGGER = LogManager.getLogger(iudx.aaa.server.token.TokenServiceTest.class);
+  private static Logger LOGGER = LogManager.getLogger(iudx.aaa.server.policy.ListPolicyTest.class);
 
-    private static Configuration config;
+  private static Configuration config;
 
-// Database Properties
+  // Database Properties
 
-    private static String databaseIP;
-    private static int databasePort;
-    private static String databaseName;
-    private static String databaseSchema;
-    private static String databaseUserName;
-    private static String databasePassword;
-    private static int poolSize;
-    private static PgPool pgclient;
-    private static PoolOptions poolOptions;
-    private static PgConnectOptions connectOptions;
-    private static PolicyService policyService;
-    private static ApdService apdService = Mockito.mock(ApdService.class);
-    private static RegistrationService registrationService;
-    private static CatalogueClient catalogueClient;
-    private static JsonObject authOptions;
-    private static JsonObject catOptions;
+  private static String databaseIP;
+  private static int databasePort;
+  private static String databaseName;
+  private static String databaseSchema;
+  private static String databaseUserName;
+  private static String databasePassword;
+  private static int poolSize;
+  private static PgPool pgclient;
+  private static PoolOptions poolOptions;
+  private static PgConnectOptions connectOptions;
+  private static PolicyService policyService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
+  private static RegistrationService registrationService;
+  private static CatalogueClient catalogueClient = Mockito.mock(CatalogueClient.class);
+  private static JsonObject authOptions;
+  private static JsonObject catOptions;
 
-    private static Vertx vertxObj;
-    private static MockRegistrationFactory mockRegistrationFactory;
+  private static Vertx vertxObj;
+  private static MockRegistrationFactory mockRegistrationFactory;
 
 
 
-    @BeforeAll
-    @DisplayName("Deploying Verticle")
-    static void startVertx(Vertx vertx, VertxTestContext testContext) {
+  @BeforeAll
+  @DisplayName("Deploying Verticle")
+  static void startVertx(Vertx vertx, VertxTestContext testContext) {
 
-        config = new Configuration();
-        vertxObj = vertx;
-        JsonObject dbConfig = config.configLoader(0, vertx);
+    config = new Configuration();
+    vertxObj = vertx;
+    JsonObject dbConfig = config.configLoader(0, vertx);
 
- //Read the configuration and set the postgres client properties.
+    // Read the configuration and set the postgres client properties.
 
-        LOGGER.debug("Info : Reading config file");
+    LOGGER.debug("Info : Reading config file");
 
-        databaseIP = dbConfig.getString("databaseIP");
-        databasePort = Integer.parseInt(dbConfig.getString("databasePort"));
-        databaseName = dbConfig.getString("databaseName");
-        databaseSchema = dbConfig.getString("databaseSchema");
-        databaseUserName = dbConfig.getString("databaseUserName");
-        databasePassword = dbConfig.getString("databasePassword");
-        poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
-        authOptions = dbConfig.getJsonObject("authOptions");
-        catOptions = dbConfig.getJsonObject("catOptions");
-        
-        /*
-         * Injecting authServerUrl into 'authOptions' from config().'authServerDomain'
-         * TODO - make this uniform
-         */
-        authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
+    databaseIP = dbConfig.getString("databaseIP");
+    databasePort = Integer.parseInt(dbConfig.getString("databasePort"));
+    databaseName = dbConfig.getString("databaseName");
+    databaseSchema = dbConfig.getString("databaseSchema");
+    databaseUserName = dbConfig.getString("databaseUserName");
+    databasePassword = dbConfig.getString("databasePassword");
+    poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
+    authOptions = dbConfig.getJsonObject("authOptions");
+    catOptions = dbConfig.getJsonObject("catOptions");
+
+    /*
+     * Injecting authServerUrl into 'authOptions' from config().'authServerDomain' TODO - make this
+     * uniform
+     */
+    authOptions.put("authServerUrl", dbConfig.getString("authServerDomain"));
 
     /* Set Connection Object and schema */
     if (connectOptions == null) {
       Map<String, String> schemaProp = Map.of("search_path", databaseSchema);
 
-      connectOptions = new PgConnectOptions().setPort(databasePort).setHost(databaseIP)
-          .setDatabase(databaseName).setUser(databaseUserName).setPassword(databasePassword)
-          .setProperties(schemaProp);
+      connectOptions =
+          new PgConnectOptions().setPort(databasePort).setHost(databaseIP).setDatabase(databaseName)
+              .setUser(databaseUserName).setPassword(databasePassword).setProperties(schemaProp);
     }
 
- //Pool options
+    // Pool options
 
-        if (poolOptions == null) {
-            poolOptions = new PoolOptions().setMaxSize(poolSize);
-        }
-
- //Create the client pool
-
-        pgclient = PgPool.pool(vertx, connectOptions, poolOptions);
-
-        mockRegistrationFactory = new MockRegistrationFactory();
-        registrationService = mockRegistrationFactory.getInstance();
-        policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
-            catalogueClient, authOptions, catOptions);
-        testContext.completeNow();
+    if (poolOptions == null) {
+      poolOptions = new PoolOptions().setMaxSize(poolSize);
     }
 
+    // Create the client pool
+
+    pgclient = PgPool.pool(vertx, connectOptions, poolOptions);
+
+    mockRegistrationFactory = new MockRegistrationFactory();
+    registrationService = mockRegistrationFactory.getInstance();
+    policyService = new PolicyServiceImpl(pgclient, registrationService, apdService,
+        catalogueClient, authOptions, catOptions);
+    testContext.completeNow();
+  }
+
+  @AfterAll
+  public static void finish(VertxTestContext testContext) {
+    LOGGER.info("Finishing....");
+    vertxObj.close(testContext.succeeding(response -> testContext.completeNow()));
+  }
+
+  @Test
+  @DisplayName("ListPolicy Success provider")
+  void listPolicySuccessProvider(VertxTestContext testContext) {
+
+    Mockito.doAnswer(i -> {
+      Map<UUID, String> result = new HashMap<UUID, String>();
+      Set<UUID> ids = i.getArgument(0);
+      for (UUID x : ids) {
+        result.put(x, "<cat-id-placeholder>");
+      }
+      return Future.succeededFuture(result);
+    }).when(catalogueClient).getCatIds(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject result = new JsonObject();
+      List<String> ids = i.getArgument(0);
+      for (String x : ids) {
+        result.put(x, new JsonObject());
+      }
+      p.complete(result);
+      return i.getMock();
+    }).when(apdService).getApdDetails(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject result = new JsonObject();
+      List<String> ids = i.getArgument(0);
+      for (String x : ids) {
+        result.put(x, new JsonObject());
+      }
+      p.complete(result);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    policyService.listPolicy(validListPolicyProvider, new JsonObject(),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
+          testContext.completeNow();
+        })));
+  }
 
 
-    @AfterAll
-    public static void finish(VertxTestContext testContext) {
-        LOGGER.info("Finishing....");
-        vertxObj.close(testContext.succeeding(response -> testContext.completeNow()));
-    }
+  @Test
+  @DisplayName("ListPolicy Success consumer")
+  void listPolicySuccessConsumer(VertxTestContext testContext) {
 
-    @Test
-    @DisplayName("ListPolicy Success provider")
-    void listPolicySuccessProvider(VertxTestContext testContext) {
+    Mockito.doAnswer(i -> {
+      Map<UUID, String> result = new HashMap<UUID, String>();
+      Set<UUID> ids = i.getArgument(0);
+      for (UUID x : ids) {
+        result.put(x, "<cat-id-placeholder>");
+      }
+      return Future.succeededFuture(result);
+    }).when(catalogueClient).getCatIds(any(), any());
 
-        mockRegistrationFactory.setResponse("valid");
-        policyService.listPolicy(validListPolicyProvider, new JsonObject(),
-                testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
-                    testContext.completeNow();
-                })));
-    }
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject result = new JsonObject();
+      List<String> ids = i.getArgument(0);
+      for (String x : ids) {
+        result.put(x, new JsonObject());
+      }
+      p.complete(result);
+      return i.getMock();
+    }).when(apdService).getApdDetails(any(), any());
 
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject result = new JsonObject();
+      List<String> ids = i.getArgument(0);
+      for (String x : ids) {
+        result.put(x, new JsonObject());
+      }
+      p.complete(result);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
 
-    @Test
-    @DisplayName("ListPolicy Success consumer")
-    void listPolicySuccessConsumer(VertxTestContext testContext) {
+    policyService.listPolicy(validListPolicyConsumer, new JsonObject(),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
+          testContext.completeNow();
+        })));
+  }
 
-        mockRegistrationFactory.setResponse("valid");
-        policyService.listPolicy(validListPolicyConsumer, new JsonObject(),
-                testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
-                    testContext.completeNow();
-                })));
-    }
+  @Test
+  @DisplayName("ListPolicy Success no policy")
+  void listPolicySuccess(VertxTestContext testContext) {
 
-    @Test
-    @DisplayName("ListPolicy Success no policy")
-    void listPolicySuccess(VertxTestContext testContext) {
+    policyService.listPolicy(invalidListPolicy, new JsonObject(),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
+          testContext.completeNow();
+        })));
+  }
 
-        mockRegistrationFactory.setResponse("valid");
-        policyService.listPolicy(invalidListPolicy, new JsonObject(),
-                testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
-                    testContext.completeNow();
-                })));
-    }
+  @Test
+  @DisplayName("ListPolicy failure")
+  void listPolicyFailure(VertxTestContext testContext) {
 
-    @Test
-    @DisplayName("ListPolicy failure")
-    void listPolicyFailure(VertxTestContext testContext) {
-
-        mockRegistrationFactory.setResponse("invalid");
-        policyService.listPolicy(validListPolicyProvider, new JsonObject(),
-                testContext.failing(response -> testContext.verify(() -> {
-                    assertEquals(INTERNALERROR, response.getMessage());
-                    testContext.completeNow();
-                })));
-    }
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      p.fail("Failure");
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+    policyService.listPolicy(validListPolicyProvider, new JsonObject(),
+        testContext.failing(response -> testContext.verify(() -> {
+          assertEquals(INTERNALERROR, response.getMessage());
+          testContext.completeNow();
+        })));
+  }
 }
 

--- a/src/test/java/iudx/aaa/server/policy/TestRequest.java
+++ b/src/test/java/iudx/aaa/server/policy/TestRequest.java
@@ -101,7 +101,7 @@ public class TestRequest {
 
   // Requests for List Policy
   public static User validListPolicyProvider =
-      new User(new JsonObject().put("userId", "a13eb955-c691-4fd3-b200-f18bc78810b5"));
+      new User(new JsonObject().put("userId", "844e251b-574b-46e6-9247-f76f1f70a637"));
 
   // List as a consumer
   public static User validListPolicyConsumer =

--- a/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
@@ -7,6 +7,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.apd.ApdService;
 import iudx.aaa.server.apiserver.util.ComposeException;
 import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.registration.RegistrationService;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Map;
@@ -55,6 +57,7 @@ public class VerifyPolicyTest {
   private static PoolOptions poolOptions;
   private static PgConnectOptions connectOptions;
   private static PolicyService policyService;
+  private static ApdService apdService = Mockito.mock(ApdService.class);
   private static RegistrationService registrationService;
   private static CatalogueClient catalogueClient;
   private static JsonObject catalogueOptions;
@@ -119,8 +122,8 @@ public class VerifyPolicyTest {
     PgPool pool = PgPool.pool(vertx, connectOptions, poolOptions);
     registrationService = RegistrationService.createProxy(vertx, REGISTRATION_SERVICE_ADDRESS);
     catalogueClient = new CatalogueClient(vertx, pool, catalogueOptions);
-    policyService =
-        new PolicyServiceImpl(pool, registrationService, catalogueClient, authOptions, catOptions);
+    policyService = new PolicyServiceImpl(pool, registrationService, apdService, catalogueClient,
+        authOptions, catOptions);
     testContext.completeNow();
   }
 


### PR DESCRIPTION
- Include ApdService in Policy Service 

- Listing of APD policies (`apd_policies` table)
- Listing of policies set for the `APD` resource type

CatalogueClient
---------------
- Added `getCatIds` method to get cat ID from resource/resource group item ID

PolicyServiceImpl
-----------------
- Update listPolicy
- Added `getUrlAndCatIds` to get cat ID and URLs of resource/resource group and resource server

ListPolicyTest
------------------
- Currently not testing APD policies
- Added mocking for `catalogueClient`, `apdService`
- Updated mocking of `registrationService` (not using `mockRegistrationFactory`)