### PR TITLE
non-root image for aaa-server

### DIFF
--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -6,8 +6,8 @@ COMMIT_ID=`git log -1 --pretty=%h`
 # last commit-id in short form
 
 # To be executed from project root
-docker build -t dockerhub.iudx.io/iudx/aaa-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/depl.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/aaa-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
+docker build -t  ghcr.io/datakaveri/aaa-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/depl.dockerfile . && \
+docker push ghcr.io/datakaveri/aaa-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
 
-docker build -t dockerhub.iudx.io/iudx/aaa-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/dev.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/aaa-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
+docker build -t ghcr.io/datakaveri/aaa-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/dev.dockerfile . && \
+docker push ghcr.io/datakaveri/aaa-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -24,11 +24,10 @@ WORKDIR /usr/share/app
 # Copying openapi docs 
 COPY docs docs
 
-# Copying dev fatjar from builder stage to final image
+# Copying cluster fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
 
-EXPOSE 8080
-EXPOSE 8443
+EXPOSE 8080 8443
 
 # Creating a non-root user
 RUN useradd -r -u 1001 -g root aaa-user

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -1,24 +1,37 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:3-openjdk-11-slim as dependencies
+# Using maven base image in builder stage to build Java code.
+FROM maven:3-openjdk-11-slim as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
+
+# Downloads all packages defined in pom.xml
 RUN mvn clean package
-
-FROM dependencies as builder
-
-WORKDIR /usr/share/app
-COPY pom.xml .
 COPY src src
+
+# Build the source code to generate the fatjar
 RUN mvn clean package -Dmaven.test.skip=true
 
-
+# Java Runtime as the base for final image
 FROM openjdk:11-jre-slim-buster
 
 ARG VERSION
 ENV JAR="iudx.aaa.server-cluster-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
+
+# Copying openapi docs 
 COPY docs docs
+
+# Copying dev fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
+
+EXPOSE 8080
+EXPOSE 8443
+
+# Creating a non-root user
+RUN useradd -r -u 1001 -g root aaa-user
+
+# Setting non-root user to use when container starts
+USER aaa-user

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -27,12 +27,10 @@ COPY docs docs
 # Copying dev fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
 
-EXPOSE 8080
-EXPOSE 8443
+EXPOSE 8080 8443
 
 # Creating a non-root user
 RUN useradd -r -u 1001 -g root aaa-user
 
 # Setting non-root user to use when container starts
 USER aaa-user
-

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,26 +1,38 @@
-# Run from project root directory
-
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:3-openjdk-11-slim as dependencies
+# Using maven base image in builder stage to build Java code.
+FROM maven:3-openjdk-11-slim as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
+
+# Downloads all packages defined in pom.xml
 RUN mvn clean package
-
-FROM dependencies as builder
-
-WORKDIR /usr/share/app
-COPY pom.xml .
 COPY src src
+
+# Build the source code to generate the fatjar
 RUN mvn clean package -Dmaven.test.skip=true
 
-
+# Java Runtime as the base for final image
 FROM openjdk:11-jre-slim-buster
 
 ARG VERSION
 ENV JAR="iudx.aaa.server-dev-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
+
+# Copying openapi docs
 COPY docs docs
+
+# Copying dev fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
+
+EXPOSE 8080
+EXPOSE 8443
+
+# Creating a non-root user
+RUN useradd -r -u 1001 -g root aaa-user
+
+# Setting non-root user to use when container starts
+USER aaa-user
+


### PR DESCRIPTION
@abhi270595 
* Reduced the size of the image in comparison to the previous image.
*  Created non-root image, having username ``auth-user`` with uid ``1001``.

test:
1. checked ``docker top <container-name>``  and  the ``uid`` of process is ``1001``
```sh
hackcoderr@master-node:~/iudx/done/iudx-aaa-server$ docker top iudx-aaa-server_prod_1
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
1001                5424                5392                5                   17:17               ?                   00:01:27            java -Xmx4096m -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar --host 506f7a5912e7 -c configs/config.json
```
2.  After exec into 
     i> checked the user, using ``id`` command - it has uid ``1001``.
  ```
aaa-user@506f7a5912e7:/usr/share/app$ id
uid=1001(aaa-user) gid=0(root) groups=0(root)
```

ii) tried to remove fatjar - it's not be able to remove the jar.
```
aaa-user@506f7a5912e7:/usr/share/app$ rm -f fatjar.jar 
rm: cannot remove 'fatjar.jar': Permission denied

```
     
Any changes are required, plz let me know.
