### PR TITLE
Implement call APD service + update token API to handle APD tokens

### DIFF
--- a/src/main/java/iudx/aaa/server/apd/ApdService.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdService.java
@@ -100,4 +100,26 @@ public interface ApdService {
    */
   @Fluent
   ApdService getApdDetails(List<String> apdIds, Handler<AsyncResult<JsonObject>> handler);
+
+  /**
+   * The callApd implements the operation to call an APD to verify if a user can access a resource
+   * by belonging to a particular user class.
+   * 
+   * @param request a JsonObject containing the following keys with information required to call the
+   *        APD
+   *        <ul>
+   *        <li><em>apdId</em> : The APD ID that is to be called</li>
+   *        <li><em>userId</em> : The user ID of the user requesting access</li>
+   *        <li><em>resource</em> : The resource cat ID for which access is needed</li>
+   *        <li><em>resSerUrl</em> : The resource server URL hosting the resource</li>
+   *        <li><em>userClass</em> : The user class set in the APD policy</li>
+   *        <li><em>providerId</em> : The user ID of the provider who owns the resource</li>
+   *        <li><em>constraints</em> : JSON object containing constraints set for the APD
+   *        policy</li>
+   *        </ul>
+   * @param handler which is a request handler
+   * @return ApdService which is a Service
+   */
+  @Fluent
+  ApdService callApd(JsonObject apdContext, Handler<AsyncResult<JsonObject>> handler);
 }

--- a/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
@@ -52,6 +52,7 @@ import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.util.ComposeException;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.registration.RegistrationService;
+import iudx.aaa.server.token.TokenService;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -84,13 +85,15 @@ public class ApdServiceImpl implements ApdService {
   private ApdWebClient apdWebClient;
   private RegistrationService registrationService;
   private PolicyService policyService;
+  private TokenService tokenService;
 
   public ApdServiceImpl(PgPool pool, ApdWebClient apdWebClient, RegistrationService regService,
-      PolicyService polService, JsonObject options) {
+      PolicyService polService, TokenService tokService, JsonObject options) {
     this.pool = pool;
     this.apdWebClient = apdWebClient;
     this.registrationService = regService;
     this.policyService = polService;
+    this.tokenService = tokService;
     AUTH_SERVER_URL = options.getString(CONFIG_AUTH_URL);
   }
 

--- a/src/main/java/iudx/aaa/server/apd/ApdVerticle.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdVerticle.java
@@ -11,6 +11,7 @@ import static iudx.aaa.server.apd.Constants.DATABASE_USERNAME;
 import static iudx.aaa.server.apd.Constants.DB_CONNECT_TIMEOUT;
 import static iudx.aaa.server.apd.Constants.REGISTRATION_SERVICE_ADDRESS;
 import static iudx.aaa.server.apd.Constants.POLICY_SERVICE_ADDRESS;
+import static iudx.aaa.server.apd.Constants.TOKEN_SERVICE_ADDRESS;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.eventbus.MessageConsumer;
@@ -23,6 +24,7 @@ import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.sqlclient.PoolOptions;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.registration.RegistrationService;
+import iudx.aaa.server.token.TokenService;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,6 +62,7 @@ public class ApdVerticle extends AbstractVerticle {
   private ApdWebClient apdWebClient;
   private RegistrationService registrationService;
   private PolicyService policyService;
+  private TokenService tokenService;
 
   private ApdService apdService;
   private ServiceBinder binder;
@@ -115,8 +118,9 @@ public class ApdVerticle extends AbstractVerticle {
 
     registrationService = RegistrationService.createProxy(vertx, REGISTRATION_SERVICE_ADDRESS);
     policyService = PolicyService.createProxy(vertx, POLICY_SERVICE_ADDRESS);
-    apdService =
-        new ApdServiceImpl(pool, apdWebClient, registrationService, policyService, options);
+    tokenService = TokenService.createProxy(vertx, TOKEN_SERVICE_ADDRESS);
+    apdService = new ApdServiceImpl(pool, apdWebClient, registrationService, policyService,
+        tokenService, options);
     binder = new ServiceBinder(vertx);
     consumer = binder.setAddress(APD_SERVICE_ADDRESS).register(ApdService.class, apdService);
 

--- a/src/main/java/iudx/aaa/server/apd/ApdWebClient.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdWebClient.java
@@ -1,22 +1,35 @@
 package iudx.aaa.server.apd;
 
 import static iudx.aaa.server.apd.Constants.APD_READ_USERCLASSES_API;
+import static iudx.aaa.server.apd.Constants.APD_RESP_DETAIL;
+import static iudx.aaa.server.apd.Constants.APD_RESP_TYPE;
+import static iudx.aaa.server.apd.Constants.APD_URN_ALLOW;
+import static iudx.aaa.server.apd.Constants.APD_URN_DENY;
+import static iudx.aaa.server.apd.Constants.APD_URN_REGEX;
+import static iudx.aaa.server.apd.Constants.APD_VERIFY_API;
+import static iudx.aaa.server.apd.Constants.APD_VERIFY_AUTH_HEADER;
+import static iudx.aaa.server.apd.Constants.APD_VERIFY_BEARER;
 import static iudx.aaa.server.apd.Constants.ERR_DETAIL_APD_NOT_RESPOND;
 import static iudx.aaa.server.apd.Constants.ERR_TITLE_APD_NOT_RESPOND;
-import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import static iudx.aaa.server.apiserver.util.Urn.*;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
-import static iudx.aaa.server.apiserver.util.Urn.*;
 import iudx.aaa.server.apiserver.util.ComposeException;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * 
@@ -32,6 +45,9 @@ public class ApdWebClient {
     this.webClient = wc;
   }
 
+  static Response failureResponse = new ResponseBuilder().type(URN_INVALID_INPUT)
+      .title(ERR_TITLE_APD_NOT_RESPOND).detail(ERR_DETAIL_APD_NOT_RESPOND).status(400).build();
+
   /**
    * The function is used to check if the Access Policy Domain exists. This is needed when the APD
    * is being registered. The read user class API is called on the URL provided. A succeeded future
@@ -44,9 +60,6 @@ public class ApdWebClient {
    */
   public Future<Boolean> checkApdExists(String url) {
     Promise<Boolean> promise = Promise.promise();
-    Response failureResponse = new ResponseBuilder().type(URN_INVALID_INPUT)
-        .title(ERR_TITLE_APD_NOT_RESPOND).detail(ERR_DETAIL_APD_NOT_RESPOND).status(400).build();
-
     RequestOptions options = new RequestOptions();
     options.setHost(url).setPort(443).setURI(APD_READ_USERCLASSES_API);
 
@@ -67,5 +80,84 @@ public class ApdWebClient {
           promise.fail(new ComposeException(failureResponse));
         });
     return promise.future();
+  }
+
+  /**
+   * Call an APD's verify endpoint.
+   * 
+   * @param url the URL of the APD
+   * @param authToken the auth server token to be added as an Authorization header
+   * @param request the JSON request body
+   * @return a future. A succeeded future with a JSON object is returned if the APD responds as
+   *         expected. A failed future with a ComposeException is returned otherwise.
+   */
+  public Future<JsonObject> callVerifyApdEndpoint(String url, String authToken,
+      JsonObject request) {
+    Promise<JsonObject> promise = Promise.promise();
+    
+    RequestOptions options = new RequestOptions();
+    options.setHost(url).setPort(443).setURI(APD_VERIFY_API);
+    options.addHeader(APD_VERIFY_AUTH_HEADER, APD_VERIFY_BEARER + authToken);
+
+    webClient.request(HttpMethod.POST, options).expect(ResponsePredicate.JSON)
+        .sendJsonObject(request).compose(body -> checkApdResponse(body))
+        .onSuccess(resp -> {
+          promise.complete(resp);
+          LOGGER.info("APD {} responded to access request by {}", url,
+              request.getJsonObject("user").getString("id"));
+        }).onFailure(err -> {
+          LOGGER.error(err.getMessage());
+          promise.fail(new ComposeException(failureResponse));
+        });
+    return promise.future();
+  }
+
+  /**
+   * Check if the response sent back by the APD after querying the verify endpoint has:
+   * <ul>
+   * <li>HTTP status code 200 or 403</li>
+   * <li>Is valid JSON</li>
+   * <li>Has <i>type</i> keyword with value either <i>allow URN/deny URN</i></li>
+   * <li>If <i>deny URN</i>, then must contain <i>detail</i> also</li>
+   * <li>If the appropriate URN+status code combo is sent.</li>
+   * </ul>
+   * 
+   * @param body the buffer response from the web client
+   * @return a future with the JSON object body if all checks pass. Else a failed future is
+   *         returned.
+   */
+  Future<JsonObject> checkApdResponse(HttpResponse<Buffer> body) {
+    /* TODO: Consider using JSON schema validation for this */
+
+    int code = body.statusCode();
+    Set<Integer> allowedCodes = Set.of(200, 403);
+    
+    if (!allowedCodes.contains(code)) {
+      LOGGER.warn("Status code {}, Response body : {}", code, body.bodyAsString());
+      return Future.failedFuture("Non " + allowedCodes.toString() + " status code sent by APD");
+    }
+
+    JsonObject json;
+
+    try {
+      json = body.bodyAsJsonObject();
+    } catch (DecodeException e) {
+      return Future.failedFuture("Invalid JSON sent by APD");
+    }
+
+    if (!json.containsKey(APD_RESP_TYPE) || !json.getString(APD_RESP_TYPE).matches(APD_URN_REGEX)) {
+      return Future.failedFuture("No/invalid URN in APD response");
+    }
+
+    if (json.getString(APD_RESP_TYPE).equals(APD_URN_DENY)
+        && (!json.containsKey(APD_RESP_DETAIL) || code != 403)) {
+      return Future.failedFuture("Invalid status+URN or no detail in APD response");
+    }
+
+    if (json.getString(APD_RESP_TYPE).equals(APD_URN_ALLOW) && code != 200) {
+      return Future.failedFuture("Invalid status+URN");
+    }
+
+    return Future.succeededFuture(json);
   }
 }

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -92,7 +92,9 @@ public class Constants {
   /* Allowed APD URNs */
   public static final String APD_URN_ALLOW = "urn:apd:Allow";
   public static final String APD_URN_DENY = "urn:apd:Deny";
-  public static final String APD_URN_REGEX = "^(" + APD_URN_ALLOW + "|" + APD_URN_DENY + ")$";
+  public static final String APD_URN_DENY_NEEDS_INT = "urn:apd:DenyNeedsInteraction";
+  public static final String APD_URN_REGEX =
+      "^(" + APD_URN_ALLOW + "|" + APD_URN_DENY + "|" + APD_URN_DENY_NEEDS_INT + ")$";
   
   /* APD JSON request keys */
   public static final String APD_REQ_USER = "user";

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -79,6 +79,44 @@ public class Constants {
 
   public static final String SQL_UPDATE_APD_STATUS =
       "UPDATE apds SET status = $1::apd_status_enum, updated_at = NOW() WHERE id = $2::uuid";
+  
+  public static final String SQL_GET_APD_URL_STATUS =
+      "SELECT url, status FROM apds WHERE id = $1::uuid";
 
+  /* APD API endpoints and request metadata */
   public static final String APD_READ_USERCLASSES_API = "/userclasses";
+  public static final String APD_VERIFY_API = "/verify";
+  public static final String APD_VERIFY_AUTH_HEADER = "Authorization";
+  public static final String APD_VERIFY_BEARER = "Bearer ";
+  
+  /* Allowed APD URNs */
+  public static final String APD_URN_ALLOW = "urn:apd:Allow";
+  public static final String APD_URN_DENY = "urn:apd:Deny";
+  public static final String APD_URN_REGEX = "^(" + APD_URN_ALLOW + "|" + APD_URN_DENY + ")$";
+  
+  /* APD JSON request keys */
+  public static final String APD_REQ_USER = "user";
+  public static final String APD_REQ_PROVIDER = "provider";
+  public static final String APD_REQ_RESOURCE =  "resource";
+  public static final String APD_REQ_USERCLASS = "userClass";
+  
+  /* APD JSON response keys */
+  public static final String APD_RESP_TYPE = "type";
+  public static final String APD_RESP_TITLE = "title";
+  public static final String APD_RESP_DETAIL = "detail";
+  public static final String APD_RESP_SESSIONID = "sessionId";
+  public static final String APD_RESP_LINK = "link";
+  
+  /* create token service JSON key/values */
+  public static final String CREATE_TOKEN_URL = "url";
+  public static final String CREATE_TOKEN_CONSTRAINTS = "constraints";
+  public static final String CREATE_TOKEN_CAT_ID = "cat_id";
+  public static final String CREATE_TOKEN_SESSIONID = "session_id";
+  public static final String CREATE_TOKEN_LINK = "link";
+  public static final String CREATE_TOKEN_STATUS = "status";
+  public static final String CREATE_TOKEN_SUCCESS = "success";
+  public static final String CREATE_TOKEN_APD_INTERAC = "apd-interaction";
+  
+  public static final String APD_NOT_ACTIVE = " (NOTE: The APD is currently not in an active state.)";
+  public static final String ERR_TITLE_POLICY_EVAL_FAILED = "Policy evaluation failed";
 }

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -4,6 +4,7 @@ public class Constants {
 
   public static final String REGISTRATION_SERVICE_ADDRESS = "iudx.aaa.registration.service";
   public static final String POLICY_SERVICE_ADDRESS = "iudx.aaa.policy.service";
+  public static final String TOKEN_SERVICE_ADDRESS = "iudx.aaa.token.service";
 
   public static final String NIL_UUID = "00000000-0000-0000-0000-000000000000";
 

--- a/src/main/java/iudx/aaa/server/apiserver/Response.java
+++ b/src/main/java/iudx/aaa/server/apiserver/Response.java
@@ -16,6 +16,16 @@ public class Response {
   private JsonArray arrayResults;
   private JsonObject objectResults;
   private String detail;
+  private JsonObject errorContext;
+  
+  public JsonObject getErrorContext() {
+    return errorContext;
+  }
+
+  public void setErrorContext(JsonObject context) {
+    this.errorContext = context;
+  }
+
   private int status;
 
   public JsonObject getObjectResults() {
@@ -91,6 +101,10 @@ public class Response {
       j.put("status", this.status); 
     }
 
+    if (this.errorContext != null) {
+      j.put("context", this.errorContext);
+    }
+
     return j;
   }
   
@@ -105,6 +119,7 @@ public class Response {
     this.objectResults = builder.objectResults;
     this.title = builder.title;
     this.status = builder.status;
+    this.errorContext = builder.errorContext;
   }
 
   public static class ResponseBuilder {
@@ -113,6 +128,7 @@ public class Response {
     private JsonArray arrayResults = null;
     private JsonObject objectResults = null;
     private String detail = null;
+    private JsonObject errorContext = null;
     private int status;
 
     public ResponseBuilder type(String type) {
@@ -149,6 +165,12 @@ public class Response {
 
     public ResponseBuilder status(int status) {
       this.status = status;
+      return this;
+    }
+
+    public ResponseBuilder errorContext(JsonObject context) {
+      this.errorContext = new JsonObject();
+      this.errorContext = context.copy();
       return this;
     }
 

--- a/src/main/java/iudx/aaa/server/apiserver/util/ComposeException.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ComposeException.java
@@ -1,5 +1,6 @@
 package iudx.aaa.server.apiserver.util;
 
+import io.vertx.serviceproxy.ServiceException;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
 
@@ -11,9 +12,10 @@ import iudx.aaa.server.apiserver.Response.ResponseBuilder;
  * response to be created and passed on in the event of the particular failure. The Response can
  * then be sent back to the API server when the exception is caught and handled.
  */
-public class ComposeException extends Exception {
+public class ComposeException extends ServiceException {
 
   private static final long serialVersionUID = 1L;
+  public static final int COMPOSE_FUTURE_ERROR = 1338;
 
   private final Response response;
 
@@ -24,7 +26,7 @@ public class ComposeException extends Exception {
    * @param response The Response object
    */
   public ComposeException(Response response) {
-    super(response.getTitle());
+    super(COMPOSE_FUTURE_ERROR, response.getDetail());
     this.response = response;
   }
 
@@ -38,7 +40,7 @@ public class ComposeException extends Exception {
    * @param detail The appropriate reason for the error
    */
   public ComposeException(int status, String type, String title, String detail) {
-    super(title);
+    super(COMPOSE_FUTURE_ERROR, detail);
     this.response =
         new ResponseBuilder().status(status).type(type).title(title).detail(detail).build();
   }
@@ -54,7 +56,7 @@ public class ComposeException extends Exception {
    * @param detail The appropriate reason for the error
    */
   public ComposeException(int status, Urn type, String title, String detail) {
-    super(title);
+    super(COMPOSE_FUTURE_ERROR, detail);
     this.response =
             new ResponseBuilder().status(status).type(type).title(title).detail(detail).build();
   }

--- a/src/main/java/iudx/aaa/server/apiserver/util/ComposeExceptionMessageCodec.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ComposeExceptionMessageCodec.java
@@ -1,0 +1,71 @@
+package iudx.aaa.server.apiserver.util;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Message codec for {@link iudx.aaa.server.apiserver.util.ComposeException}. This is used to decode
+ * and encode ComposeException accross the event bus. This is especially necessary for clustered
+ * vert.x. {@link iudx.aaa.server.deploy.Deployer} and {@link iudx.aaa.server.DeployerDev} add this
+ * message codec to the vertx object.
+ *
+ */
+public class ComposeExceptionMessageCodec
+    implements MessageCodec<ComposeException, ComposeException> {
+
+  @Override
+  public void encodeToWire(Buffer buffer, ComposeException customMessage) {
+    // Easiest ways is using JSON object
+    JsonObject jsonToEncode = customMessage.getResponse().toJson();
+
+    // Encode object to string
+    String jsonToStr = jsonToEncode.encode();
+
+    // Length of JSON: is NOT characters count
+    int length = jsonToStr.getBytes().length;
+
+    // Write data into given buffer
+    buffer.appendInt(length);
+    buffer.appendString(jsonToStr);
+  }
+
+  @Override
+  public ComposeException decodeFromWire(int position, Buffer buffer) {
+    // My custom message starting from this *position* of buffer
+    int _pos = position;
+
+    // Length of JSON
+    int length = buffer.getInt(_pos);
+
+    // Get JSON string by it`s length
+    // Jump 4 because getInt() == 4 bytes
+    String jsonStr = buffer.getString(_pos += 4, _pos += length);
+    JsonObject contentJson = new JsonObject(jsonStr);
+
+    // We can finally create custom message object
+    /* TODO: change this so that we use Response.fromJson() or something */
+    return new ComposeException(contentJson.getInteger("status"), contentJson.getString("type"),
+        contentJson.getString("title"), contentJson.getString("detail"));
+  }
+
+  @Override
+  public ComposeException transform(ComposeException customMessage) {
+    // If a message is sent *locally* across the event bus.
+    // This example sends message just as is
+    return customMessage;
+  }
+
+  @Override
+  public String name() {
+    // Each codec must have a unique name.
+    // This is used to identify a codec when sending a message and for unregistering codecs.
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public byte systemCodecID() {
+    // Always -1
+    return -1;
+  }
+}

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -30,6 +30,8 @@ import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+import iudx.aaa.server.apiserver.util.ComposeException;
+import iudx.aaa.server.apiserver.util.ComposeExceptionMessageCodec;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -205,6 +207,13 @@ public class Deployer {
       if (res.succeeded()) {
         vertx = res.result();
         LOGGER.debug(vertx.isMetricsEnabled());
+        /*
+         * Include ComposeException message codec so that ComposeException objects can be sent
+         * accross the event bus
+         */
+        vertx.eventBus().registerDefaultCodec(ComposeException.class,
+            new ComposeExceptionMessageCodec());
+        LOGGER.debug("Added ComposeException message codec");
         setJVMmetrics();
         if (modules.isEmpty()) {
           recursiveDeploy(vertx, configuration, 0);

--- a/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
+++ b/src/main/java/iudx/aaa/server/deploy/DeployerDev.java
@@ -9,6 +9,8 @@ import io.vertx.core.cli.CLI;
 import io.vertx.core.cli.Option;
 import io.vertx.core.cli.CommandLine;
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apiserver.util.ComposeException;
+import iudx.aaa.server.apiserver.util.ComposeExceptionMessageCodec;
 import io.vertx.core.DeploymentOptions;
 
 
@@ -80,6 +82,13 @@ public class DeployerDev {
       return;
     }
     Vertx vertx = Vertx.vertx(options);
+    /*
+     * Include ComposeException message codec so that ComposeException objects can be sent accross
+     * the event bus
+     */
+    vertx.eventBus().registerDefaultCodec(ComposeException.class,
+        new ComposeExceptionMessageCodec());
+    LOGGER.debug("Added ComposeException message codec");
     recursiveDeploy(vertx, configuration, 0);
   }
 

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -42,9 +42,11 @@ public class Constants {
   public static final String ALLOW = "allow";
   public static final String DENY = "deny";
   public static final String SUCCESS = "success";
+  public static final String APD_INTERACTION = "apd-interaction";
   public static final String FAILED = "failed";
   public static final String DESC = "desc";
   public static final String ACCESS_TOKEN = "accessToken";
+  public static final String APD_TOKEN = "apdToken";
   public static final String RS_URL = "rsUrl";
   public static final String HOST = "host";
   public static final String PORT = "port";
@@ -64,6 +66,7 @@ public class Constants {
   public static final String AUDIENCE = "audience";
   public static final String URL = "url";
   public static final String USER_ID = "userId";
+  public static final String SESSION_ID = "sessionId";
   public static final String CONSTRAINTS = "constraints";
   public static final String RESOURCE_SVR = "resource_server";
     
@@ -80,6 +83,11 @@ public class Constants {
   public static final String ITYPE = "ityp";
   public static final String IID = "iid";
   public static final String CONS = "cons";
+  
+  /* JWT Constants for APD token */
+  public static final String LINK = "link";
+  public static final String SID = "sid";
+
   
   public static final String GRANT_TYPE = "grant_type";
   public static final String CLIENT_CREDENTIALS = "client_credentials";
@@ -108,6 +116,10 @@ public class Constants {
   public static final String CANNOT_REVOKE_ON_AUTH = "Cannot revoke tokens on auth server";
   public static final String INVALID_POLICY = "Policy evaluation failed";
   public static final String TOKEN_SUCCESS = "Token created";
+  public static final String ERR_TITLE_APD_INTERACT_REQUIRED = "APD interaction required";
+  public static final String ERR_DETAIL_APD_INTERACT_REQUIRED =
+      "The APD requires extra information to grant access."
+      + " Please use the apdToken and visit the link to interact with the APD";
   public static final String TOKEN_REVOKED = "Token revoked";
   public static final String TOKEN_AUTHENTICATED = "Token authenticated";
   public static final String INVALID_USERID = "Empty/null userId";

--- a/src/main/java/iudx/aaa/server/token/TokenService.java
+++ b/src/main/java/iudx/aaa/server/token/TokenService.java
@@ -80,4 +80,15 @@ public interface TokenService {
   @Fluent
   TokenService validateToken(IntrospectToken introspectToken, Handler<AsyncResult<JsonObject>> handler);
 
+  /**
+   * Get an auth server JWT token. This token is used by the Auth server when calling other servers to
+   * authenticate itself.
+   * 
+   * @param audienceUrl the URL of the server to be called. The <i>aud</i> field in the token will contain
+   * this URL.
+   * @param handler which is a Request Handler
+   * @return TokenService which is a Service
+   */
+  @Fluent
+  TokenService getAuthServerToken(String audienceUrl, Handler<AsyncResult<JsonObject>> handler);
 }

--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -392,6 +392,18 @@ public class TokenServiceImpl implements TokenService {
   }
   
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public TokenService getAuthServerToken(String audienceUrl,
+      Handler<AsyncResult<JsonObject>> handler) {
+    JsonObject adminTokenReq = new JsonObject().put(USER_ID, CLAIM_ISSUER).put(URL, audienceUrl)
+        .put(ROLE, "").put(ITEM_TYPE, "").put(ITEM_ID, "");
+    handler.handle(Future.succeededFuture(getJwt(adminTokenReq)));
+    return this;
+  }
+  
+  /**
    * Handles the PostgreSQL query.
    * 
    * @param query which is SQL

--- a/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/token/TokenServiceImpl.java
@@ -20,6 +20,7 @@ import iudx.aaa.server.apiserver.RequestToken;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.RevokeToken;
 import iudx.aaa.server.apiserver.User;
+import iudx.aaa.server.apiserver.util.ComposeException;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
 import iudx.aaa.server.policy.PolicyService;
 import java.util.List;
@@ -142,23 +143,40 @@ public class TokenServiceImpl implements TokenService {
         }
       });
     } else {
-      policyService.verifyPolicy(request, policyHandler -> {
-        if (policyHandler.succeeded()) {
+      Promise<JsonObject> policyHandler = Promise.promise();
+      policyService.verifyPolicy(request, policyHandler);
+      policyHandler.future().onSuccess(result -> {
 
-          request.mergeIn(policyHandler.result(), true);
+        request.mergeIn(result, true);
+
+        if (request.getString(STATUS).equals(SUCCESS)) {
+         
           JsonObject jwt = getJwt(request);
-
-          LOGGER.info(LOG_TOKEN_SUCC);
-          Response resp = new ResponseBuilder().status(200).type(URN_SUCCESS).title(TOKEN_SUCCESS)
-              .objectResults(jwt).build();
-          handler.handle(Future.succeededFuture(resp.toJson()));
-
-        } else if (policyHandler.failed()) {
-          LOGGER.error("Fail: {}; {}", INVALID_POLICY, policyHandler.cause().getMessage());
-          Response resp = new ResponseBuilder().status(403).type(URN_INVALID_INPUT)
-              .title(INVALID_POLICY).detail(policyHandler.cause().getLocalizedMessage()).build();
-          handler.handle(Future.succeededFuture(resp.toJson()));
+        Response resp = new ResponseBuilder().status(200).type(URN_SUCCESS).title(TOKEN_SUCCESS)
+            .objectResults(jwt).build();
+        
+        handler.handle(Future.succeededFuture(resp.toJson()));
+        } else if (request.getString(STATUS).equals(APD_INTERACTION)) {
+          
+          JsonObject apdJwt = getApdJwt(request);
+          /* Add context to the error response containing the APD token */
+          Response resp = new ResponseBuilder().status(403).type(URN_MISSING_INFO)
+              .title(ERR_TITLE_APD_INTERACT_REQUIRED).detail(ERR_DETAIL_APD_INTERACT_REQUIRED)
+              .errorContext(apdJwt).build();
+          
+        handler.handle(Future.succeededFuture(resp.toJson()));
         }
+
+        LOGGER.info(LOG_TOKEN_SUCC);
+
+      }).onFailure(fail -> {
+        if (fail instanceof ComposeException) {
+          ComposeException exp = (ComposeException) fail;
+          handler.handle(Future.succeededFuture(exp.getResponse().toJson()));
+          return;
+        }
+        LOGGER.error(fail.getMessage());
+        handler.handle(Future.failedFuture("Internal error"));
       });
     }
     
@@ -388,6 +406,46 @@ public class TokenServiceImpl implements TokenService {
     JsonObject tokenResp = new JsonObject();
     tokenResp.put(ACCESS_TOKEN, token).put("expiry", expiry).put("server",
         audience);
+    return tokenResp;
+  }
+
+  /**
+   * Generates the JWT token used for APD interaction using the request data.
+   * 
+   * @param request a JSON object containing
+   *        <ul>
+   *        <li><em>url</em> : The URL of the APD to be called. This is placed in the <em>aud</em>
+   *        field</li>
+   *        <li><em>userId</em> : The user ID of the user requesting access</li>
+   *        <li><em>sessionId</em> : The sessionId sent by the APD</li>
+   *        <li><em>link</em> : The link to visit sent by the APD</li>
+   *        </ul>
+   * @return jwtToken a JSON object containing the <i>accessToken</i>, expiry and server (audience)
+   */
+  public JsonObject getApdJwt(JsonObject request) {
+    
+    JWTOptions options = new JWTOptions().setAlgorithm(JWT_ALGORITHM);
+    long timestamp = System.currentTimeMillis() / 1000;
+    long expiry = timestamp + CLAIM_EXPIRY;
+    String sessionId = request.getString(SESSION_ID);
+    String link = request.getString(LINK);
+    String audience = request.getString(URL);
+    
+    /* Populate the token claims */
+    JsonObject claims = new JsonObject();
+    claims.put(SUB, request.getString(USER_ID))
+          .put(ISS, CLAIM_ISSUER)
+          .put(AUD, audience)
+          .put(EXP, expiry)
+          .put(IAT, timestamp)
+          .put(SID, sessionId)
+          .put(LINK, link);
+    
+    String token = provider.generateToken(claims, options);
+
+    JsonObject tokenResp = new JsonObject();
+    tokenResp.put(APD_TOKEN, token).put("expiry", expiry).put("server",
+        audience).put(LINK, link);
     return tokenResp;
   }
   

--- a/src/test/java/iudx/aaa/server/apd/CallApdTest.java
+++ b/src/test/java/iudx/aaa/server/apd/CallApdTest.java
@@ -1,0 +1,434 @@
+package iudx.aaa.server.apd;
+
+import static iudx.aaa.server.apd.Constants.APD_NOT_ACTIVE;
+import static iudx.aaa.server.apd.Constants.APD_RESP_DETAIL;
+import static iudx.aaa.server.apd.Constants.APD_RESP_LINK;
+import static iudx.aaa.server.apd.Constants.APD_RESP_SESSIONID;
+import static iudx.aaa.server.apd.Constants.APD_RESP_TYPE;
+import static iudx.aaa.server.apd.Constants.APD_URN_ALLOW;
+import static iudx.aaa.server.apd.Constants.APD_URN_DENY;
+import static iudx.aaa.server.apd.Constants.CONFIG_AUTH_URL;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_APD_INTERAC;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_CAT_ID;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_CONSTRAINTS;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_LINK;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_SESSIONID;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_STATUS;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_SUCCESS;
+import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_URL;
+import static iudx.aaa.server.apd.Constants.ERR_DETAIL_APD_NOT_RESPOND;
+import static iudx.aaa.server.apd.Constants.ERR_TITLE_APD_NOT_RESPOND;
+import static iudx.aaa.server.apd.Constants.ERR_TITLE_POLICY_EVAL_FAILED;
+import static iudx.aaa.server.apiserver.util.Urn.URN_INVALID_INPUT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Tuple;
+import iudx.aaa.server.apiserver.ApdStatus;
+import iudx.aaa.server.apiserver.Response;
+import iudx.aaa.server.apiserver.Response.ResponseBuilder;
+import iudx.aaa.server.apiserver.RoleStatus;
+import iudx.aaa.server.apiserver.Roles;
+import iudx.aaa.server.apiserver.util.ComposeException;
+import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
+import iudx.aaa.server.registration.RegistrationService;
+import iudx.aaa.server.registration.Utils;
+import iudx.aaa.server.token.TokenService;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+@ExtendWith({VertxExtension.class})
+public class CallApdTest {
+  private static Logger LOGGER = LogManager.getLogger(CallApdTest.class);
+
+  private static Configuration config;
+
+  private static String databaseIP;
+  private static int databasePort;
+  private static String databaseName;
+  private static String databaseSchema;
+  private static String databaseUserName;
+  private static String databasePassword;
+  private static int poolSize;
+  private static Vertx vertxObj;
+  private static ApdService apdService;
+
+  private static PgPool pool;
+  private static PoolOptions poolOptions;
+  private static PgConnectOptions connectOptions;
+  private static ApdWebClient apdWebClient = Mockito.mock(ApdWebClient.class);
+  private static RegistrationService registrationService = Mockito.mock(RegistrationService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
+  private static TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private static final String DUMMY_AUTH_SERVER =
+      "auth" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + "iudx.io";
+  private static Future<JsonObject> trusteeUser;
+  private static Future<JsonObject> otherUser;
+
+  static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+  static String url = name + ".com";
+  static Future<UUID> orgIdFut;
+
+  private static final UUID PENDING_APD_ID = UUID.randomUUID();
+  private static final UUID ACTIVE_APD_ID = UUID.randomUUID();
+
+  private static final String PENDING_APD = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+  private static final String ACTIVE_APD = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+
+  @BeforeAll
+  @DisplayName("Deploying Verticle")
+  static void startVertx(Vertx vertx, VertxTestContext testContext) {
+    config = new Configuration();
+    vertxObj = vertx;
+    JsonObject dbConfig = config.configLoader(4, vertx);
+
+    /* Read the configuration and set the postgres client properties. */
+    LOGGER.debug("Info : Reading config file");
+
+    databaseIP = dbConfig.getString("databaseIP");
+    databasePort = Integer.parseInt(dbConfig.getString("databasePort"));
+    databaseName = dbConfig.getString("databaseName");
+    databaseSchema = dbConfig.getString("databaseSchema");
+    databaseUserName = dbConfig.getString("databaseUserName");
+    databasePassword = dbConfig.getString("databasePassword");
+    poolSize = Integer.parseInt(dbConfig.getString("poolSize"));
+
+    /* Set Connection Object and schema */
+    if (connectOptions == null) {
+      Map<String, String> schemaProp = Map.of("search_path", databaseSchema);
+
+      connectOptions =
+          new PgConnectOptions().setPort(databasePort).setHost(databaseIP).setDatabase(databaseName)
+              .setUser(databaseUserName).setPassword(databasePassword).setProperties(schemaProp);
+    }
+
+    /* Pool options */
+    if (poolOptions == null) {
+      poolOptions = new PoolOptions().setMaxSize(poolSize);
+    }
+
+    pool = PgPool.pool(vertx, connectOptions, poolOptions);
+
+    /* Do not take test config, use generated config */
+    JsonObject options = new JsonObject().put(CONFIG_AUTH_URL, DUMMY_AUTH_SERVER);
+
+    orgIdFut = pool.withConnection(conn -> conn.preparedQuery(Utils.SQL_CREATE_ORG)
+        .execute(Tuple.of(name, url)).map(row -> row.iterator().next().getUUID("id")));
+    trusteeUser = orgIdFut.compose(orgId -> Utils.createFakeUser(pool, orgId.toString(), "",
+        Map.of(Roles.TRUSTEE, RoleStatus.APPROVED), false));
+    otherUser = orgIdFut.compose(orgId -> Utils.createFakeUser(pool, orgId.toString(), "",
+        Map.of(Roles.CONSUMER, RoleStatus.APPROVED), false));
+
+    CompositeFuture.all(trusteeUser, otherUser).compose(s -> {
+      UUID trusteeId = UUID.fromString(trusteeUser.result().getString("userId"));
+      List<Tuple> apdTup = List.of(
+          Tuple.of(PENDING_APD_ID, PENDING_APD, PENDING_APD + ".com", trusteeId, ApdStatus.PENDING),
+          Tuple.of(ACTIVE_APD_ID, ACTIVE_APD, ACTIVE_APD + ".com", trusteeId, ApdStatus.ACTIVE));
+
+      return pool
+          .withConnection(conn -> conn.preparedQuery(Utils.SQL_CREATE_APD).executeBatch(apdTup));
+    }).onSuccess(res -> {
+      apdService = new ApdServiceImpl(pool, apdWebClient, registrationService, policyService,
+          tokenService, options);
+      testContext.completeNow();
+    });
+  }
+
+  @AfterAll
+  public static void finish(VertxTestContext testContext) {
+    LOGGER.info("Finishing....");
+    List<JsonObject> users = List.of(trusteeUser.result(), otherUser.result());
+
+    Utils.deleteFakeUser(pool, users)
+        .compose(succ -> pool.withConnection(
+            conn -> conn.preparedQuery(Utils.SQL_DELETE_ORG).execute(Tuple.of(orgIdFut.result()))))
+        .onComplete(x -> {
+          if (x.failed()) {
+            LOGGER.warn(x.cause().getMessage());
+          }
+          vertxObj.close(testContext.succeeding(response -> testContext.completeNow()));
+        });
+  }
+
+  @Test
+  @DisplayName("APD ID not found in DB - should never happen")
+  void apdIdNotExist(VertxTestContext testContext) {
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", UUID.randomUUID().toString())
+        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
+        .put("constraints", new JsonObject())
+        .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
+
+    apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
+      testContext.completeNow();
+    })));
+  }
+
+  @Test
+  @DisplayName("Registration service (get user details) failing")
+  void regServiceFail(VertxTestContext testContext) {
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      p.fail("Fail");
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
+        .put("constraints", new JsonObject())
+        .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
+
+    apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
+      testContext.completeNow();
+    })));
+  }
+
+
+  @Test
+  @DisplayName("Token service (get auth server token) failing")
+  void tokenServiceFail(VertxTestContext testContext) {
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      p.fail("Fail");
+      return i.getMock();
+    }).when(tokenService).getAuthServerToken(any(), any());
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
+        .put("constraints", new JsonObject())
+        .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
+
+    apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
+      testContext.completeNow();
+    })));
+  }
+
+  @Test
+  @DisplayName("ApdWebClient failing - incorrect/invalid response sent by APD")
+  void apdWebClientFails(VertxTestContext testContext) {
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      List<String> ids = i.getArgument(0);
+      JsonObject resp = new JsonObject();
+      for (String id : ids) {
+        resp.put(id, new JsonObject());
+      }
+      p.complete(resp);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject resp = new JsonObject().put("accessToken", RandomStringUtils.randomAlphabetic(30));
+      p.complete(resp);
+      return i.getMock();
+    }).when(tokenService).getAuthServerToken(any(), any());
+
+    Response failureResponse = new ResponseBuilder().type(URN_INVALID_INPUT)
+        .title(ERR_TITLE_APD_NOT_RESPOND).detail(ERR_DETAIL_APD_NOT_RESPOND).status(400).build();
+
+    Mockito.when(apdWebClient.callVerifyApdEndpoint(any(), any(), any()))
+        .thenReturn(Future.failedFuture(new ComposeException(failureResponse)));
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", PENDING_APD_ID.toString())
+        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
+        .put("constraints", new JsonObject())
+        .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
+
+    apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
+      ComposeException exp = (ComposeException) response;
+      Response errResp = exp.getResponse();
+      assertEquals(errResp.getType(), URN_INVALID_INPUT.toString());
+      assertEquals(errResp.getTitle(), ERR_TITLE_POLICY_EVAL_FAILED);
+      assertEquals(errResp.getDetail(), ERR_DETAIL_APD_NOT_RESPOND + APD_NOT_ACTIVE);
+      testContext.completeNow();
+    })));
+  }
+
+  @Test
+  @DisplayName("ApdWebClient success - APD allow")
+  void apdWebClientSuccessAllow(VertxTestContext testContext) {
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      List<String> ids = i.getArgument(0);
+      JsonObject resp = new JsonObject();
+      for (String id : ids) {
+        resp.put(id, new JsonObject());
+      }
+      p.complete(resp);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject resp = new JsonObject().put("accessToken", RandomStringUtils.randomAlphabetic(30));
+      p.complete(resp);
+      return i.getMock();
+    }).when(tokenService).getAuthServerToken(any(), any());
+
+    JsonObject webClientResp = new JsonObject().put(APD_RESP_TYPE, APD_URN_ALLOW);
+
+    Mockito.when(apdWebClient.callVerifyApdEndpoint(any(), any(), any()))
+        .thenReturn(Future.succeededFuture(webClientResp));
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
+    String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("userClass", userClass);
+
+    apdService.callApd(apdContext, testContext.succeeding(response -> testContext.verify(() -> {
+      assertEquals(response.getString(CREATE_TOKEN_STATUS), CREATE_TOKEN_SUCCESS);
+      assertEquals(response.getString(CREATE_TOKEN_CAT_ID), resource);
+      assertEquals(response.getString(CREATE_TOKEN_URL), resSerUrl);
+      assertEquals(response.getJsonObject(CREATE_TOKEN_CONSTRAINTS), new JsonObject());
+      testContext.completeNow();
+    })));
+  }
+
+  @Test
+  @DisplayName("ApdWebClient success - APD deny")
+  void apdWebClientSuccessDeny(VertxTestContext testContext) {
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      List<String> ids = i.getArgument(0);
+      JsonObject resp = new JsonObject();
+      for (String id : ids) {
+        resp.put(id, new JsonObject());
+      }
+      p.complete(resp);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject resp = new JsonObject().put("accessToken", RandomStringUtils.randomAlphabetic(30));
+      p.complete(resp);
+      return i.getMock();
+    }).when(tokenService).getAuthServerToken(any(), any());
+
+    JsonObject webClientResp =
+        new JsonObject().put(APD_RESP_TYPE, APD_URN_DENY).put(APD_RESP_DETAIL, "Not allowed");
+
+    Mockito.when(apdWebClient.callVerifyApdEndpoint(any(), any(), any()))
+        .thenReturn(Future.succeededFuture(webClientResp));
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
+    String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("userClass", userClass);
+
+    apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
+      ComposeException exp = (ComposeException) response;
+      Response errResp = exp.getResponse();
+      assertEquals(errResp.getType(), URN_INVALID_INPUT.toString());
+      assertEquals(errResp.getTitle(), ERR_TITLE_POLICY_EVAL_FAILED);
+      assertEquals(errResp.getDetail(), "Not allowed");
+      testContext.completeNow();
+    })));
+  }
+
+  @Test
+  @DisplayName("ApdWebClient success - APD deny and needs interaction")
+  void apdWebClientSuccessDenySessionId(VertxTestContext testContext) {
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      List<String> ids = i.getArgument(0);
+      JsonObject resp = new JsonObject();
+      for (String id : ids) {
+        resp.put(id, new JsonObject());
+      }
+      p.complete(resp);
+      return i.getMock();
+    }).when(registrationService).getUserDetails(any(), any());
+
+    Mockito.doAnswer(i -> {
+      Promise<JsonObject> p = i.getArgument(1);
+      JsonObject resp = new JsonObject().put("accessToken", RandomStringUtils.randomAlphabetic(30));
+      p.complete(resp);
+      return i.getMock();
+    }).when(tokenService).getAuthServerToken(any(), any());
+
+    String sessionId = UUID.randomUUID().toString();
+    JsonObject webClientResp =
+        new JsonObject().put(APD_RESP_TYPE, APD_URN_DENY).put(APD_RESP_DETAIL, "Needs interaction")
+            .put(APD_RESP_SESSIONID, sessionId).put(APD_RESP_LINK, ACTIVE_APD + ".com/apd");
+
+    Mockito.when(apdWebClient.callVerifyApdEndpoint(any(), any(), any()))
+        .thenReturn(Future.succeededFuture(webClientResp));
+
+    UUID userId = UUID.randomUUID();
+    UUID providerId = UUID.randomUUID();
+    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
+    String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+
+    JsonObject apdContext = new JsonObject().put("userId", userId.toString())
+        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("userClass", userClass);
+
+    apdService.callApd(apdContext, testContext.succeeding(response -> testContext.verify(() -> {
+      assertEquals(response.getString(CREATE_TOKEN_STATUS), CREATE_TOKEN_APD_INTERAC);
+      assertEquals(response.getString(CREATE_TOKEN_LINK), ACTIVE_APD + ".com/apd");
+      assertEquals(response.getString(CREATE_TOKEN_SESSIONID), sessionId);
+      assertEquals(response.getString(CREATE_TOKEN_URL), ACTIVE_APD + ".com");
+      testContext.completeNow();
+    })));
+  }
+}

--- a/src/test/java/iudx/aaa/server/apd/CallApdTest.java
+++ b/src/test/java/iudx/aaa/server/apd/CallApdTest.java
@@ -7,6 +7,7 @@ import static iudx.aaa.server.apd.Constants.APD_RESP_SESSIONID;
 import static iudx.aaa.server.apd.Constants.APD_RESP_TYPE;
 import static iudx.aaa.server.apd.Constants.APD_URN_ALLOW;
 import static iudx.aaa.server.apd.Constants.APD_URN_DENY;
+import static iudx.aaa.server.apd.Constants.APD_URN_DENY_NEEDS_INT;
 import static iudx.aaa.server.apd.Constants.CONFIG_AUTH_URL;
 import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_APD_INTERAC;
 import static iudx.aaa.server.apd.Constants.CREATE_TOKEN_CAT_ID;
@@ -406,7 +407,7 @@ public class CallApdTest {
 
     String sessionId = UUID.randomUUID().toString();
     JsonObject webClientResp =
-        new JsonObject().put(APD_RESP_TYPE, APD_URN_DENY).put(APD_RESP_DETAIL, "Needs interaction")
+        new JsonObject().put(APD_RESP_TYPE, APD_URN_DENY_NEEDS_INT).put(APD_RESP_DETAIL, "Needs interaction")
             .put(APD_RESP_SESSIONID, sessionId).put(APD_RESP_LINK, ACTIVE_APD + ".com/apd");
 
     Mockito.when(apdWebClient.callVerifyApdEndpoint(any(), any(), any()))

--- a/src/test/java/iudx/aaa/server/apd/CreateApdTest.java
+++ b/src/test/java/iudx/aaa/server/apd/CreateApdTest.java
@@ -54,6 +54,7 @@ import iudx.aaa.server.apiserver.util.ComposeException;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.registration.RegistrationService;
 import iudx.aaa.server.registration.Utils;
+import iudx.aaa.server.token.TokenService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -80,6 +81,7 @@ public class CreateApdTest {
   private static ApdWebClient apdWebClient = Mockito.mock(ApdWebClient.class);
   private static RegistrationService registrationService = Mockito.mock(RegistrationService.class);
   private static PolicyService policyService = Mockito.mock(PolicyService.class);
+  private static TokenService tokenService = Mockito.mock(TokenService.class);
 
   private static final String DUMMY_AUTH_SERVER =
       "auth" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + "iudx.io";
@@ -135,8 +137,8 @@ public class CreateApdTest {
         Map.of(Roles.PROVIDER, RoleStatus.APPROVED), false));
 
     CompositeFuture.all(trusteeUser, otherUser).onSuccess(succ -> {
-      apdService =
-          new ApdServiceImpl(pool, apdWebClient, registrationService, policyService, options);
+      apdService = new ApdServiceImpl(pool, apdWebClient, registrationService, policyService,
+          tokenService, options);
       testContext.completeNow();
     });
   }

--- a/src/test/java/iudx/aaa/server/apd/UpdateApdTest.java
+++ b/src/test/java/iudx/aaa/server/apd/UpdateApdTest.java
@@ -46,6 +46,7 @@ import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.registration.RegistrationService;
 import iudx.aaa.server.registration.Utils;
+import iudx.aaa.server.token.TokenService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -86,6 +87,7 @@ public class UpdateApdTest {
   private static ApdWebClient apdWebClient = Mockito.mock(ApdWebClient.class);
   private static RegistrationService registrationService = Mockito.mock(RegistrationService.class);
   private static PolicyService policyService = Mockito.mock(PolicyService.class);
+  private static TokenService tokenService = Mockito.mock(TokenService.class);
 
   private static final String DUMMY_SERVER =
       "dummy" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
@@ -194,8 +196,8 @@ public class UpdateApdTest {
       return pool.withConnection(conn -> conn.preparedQuery(SQL_CREATE_ADMIN_SERVER)
           .executeBatch(tup).compose(x -> conn.preparedQuery(SQL_CREATE_APD).executeBatch(apdTup)));
     }).onSuccess(x -> {
-      apdService =
-          new ApdServiceImpl(pool, apdWebClient, registrationService, policyService, options);
+      apdService = new ApdServiceImpl(pool, apdWebClient, registrationService, policyService,
+          tokenService, options);
       testContext.completeNow();
     });
   }

--- a/src/test/java/iudx/aaa/server/token/MockPolicyFactory.java
+++ b/src/test/java/iudx/aaa/server/token/MockPolicyFactory.java
@@ -6,6 +6,9 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apiserver.util.ComposeException;
+import static iudx.aaa.server.apiserver.util.Urn.*;
+import java.util.UUID;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.policy.PolicyServiceImpl;
 
@@ -49,7 +52,9 @@ public class MockPolicyFactory {
       Mockito.when(asyncResult.succeeded()).thenReturn(true);
     } else {
       response.put("status", "failed");
-      Mockito.when(asyncResult.cause()).thenReturn(new Throwable(response.toString()));
+      ComposeException exp =
+          new ComposeException(403, URN_INVALID_INPUT, "Evaluation failed", "Evaluation failed");
+      Mockito.when(asyncResult.cause()).thenReturn(exp);
       Mockito.when(asyncResult.succeeded()).thenReturn(false);
       Mockito.when(asyncResult.failed()).thenReturn(true);
     }
@@ -58,17 +63,27 @@ public class MockPolicyFactory {
   /**
    * Mock success response of verifyPolicy
    * 
-   * @param status if it is a valid/invalid call
+   * @param status if it is a valid/apd-interaction call
    * @param item the cat ID of the item
    * @param url the url of the server
    */
-  public void setResponse(String status, String item, String url) {
+  public void setResponse(String status, String itemorApdLink, String url) {
     if ("valid".equals(status)) {
     JsonObject response = new JsonObject();
       response.put("status", "success");
-      response.put("cat_id", item);
+      response.put("cat_id", itemorApdLink);
       response.put("url", url);
       response.put("constraints", new JsonObject().put("access", new JsonArray().add("api")));
+      Mockito.when(asyncResult.result()).thenReturn(response);
+      Mockito.when(asyncResult.failed()).thenReturn(false);
+      Mockito.when(asyncResult.succeeded()).thenReturn(true);
+    }
+    else if ("apd-interaction".equals(status)) {
+    JsonObject response = new JsonObject();
+      response.put("status", "apd-interaction");
+      response.put("sessionId", UUID.randomUUID().toString());
+      response.put("link", itemorApdLink);
+      response.put("url", url);
       Mockito.when(asyncResult.result()).thenReturn(response);
       Mockito.when(asyncResult.failed()).thenReturn(false);
       Mockito.when(asyncResult.succeeded()).thenReturn(true);


### PR DESCRIPTION
TokenServiceImpl
------------------------
- Add getAuthServerToken method to TokenService - this method will be used by ApdService to get an auth server token
to use when calling an APD at the verify endpoint
- Update createToken to handle APD token creation when response
comes from callApd
- The APD token is sent in the `context` object along with some
other info
- Add `getApdJwt` method to create APD token
- Updated, added test

ApdServiceImpl and ApdWebClient
---------------------
- Added callApd implementation
- In `ApdWebClient`
	- Added `callVerifyApdEndpoint` to call the verify endpoint
	- Added `checkApdResponse` to validate the APD response
- Added tests

Response
-------------
- Add errorContext field to response object. This gets added as
`context` in the JSON response, and is a JSON object that can store
any error related info in addition to detail

## Example of APD token response

```
{
  "type" : "urn:dx:as:MissingInformation",
  "title" : "APD interaction required",
  "detail" : "The APD requires extra information to grant access. Please use the apdToken and visit the link to interact with the APD",
  "status" : 403,
  "context" : {
    "apdToken" : "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiI0ODc2YTEzZS1lZTVjLTRlZDAtYWQwMS0xMWZkODMzYTlkNDUiLCJpc3MiOiJhdXRod25ucG1pdWR4LmlvIiwiYXVkIjoiZHVtbXlub2VicS5pdWR4LmlvIiwiZXhwIjoxNjQ3NDg0NzE2LCJpYXQiOjE2NDc0NDE1MTYsInNpZCI6IjBlZjk1ODhkLTg1ZDEtNDljNC1hMmYwLTU2MzBmMDkyYmFmYyIsImxpbmsiOiJkdW1teW5vZWJxLml1ZHguaW8vYXBkLWludGVyYWN0In0.InHRR8MmzOBYEtx1VIoCOqwDaUVNpfDMQ59MqvkHWnEPdcMhzUU5eMMBqYirtTDu1mc2b_B4p8CmKtSqF9xJSg",
    "expiry" : 1647484716,
    "server" : "dummynoebq.iudx.io",
    "link" : "dummynoebq.iudx.io/apd-interact"
  }
}
```