### PR TITLE
Bug-fix

### DIFF
--- a/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
@@ -341,7 +341,7 @@ public class ApdServiceImpl implements ApdService {
           .map(r -> UUID.fromString(r.getApdId())).collect(Collectors.toList());
 
       return ids.stream().map(r -> queryResult.result().get(r).getString("owner_id"))
-          .map(id -> UUID.fromString(id)).collect(Collectors.toList());
+          .map(id -> UUID.fromString(id)).distinct().collect(Collectors.toList());
     };
 
     /* Function to get list of trustee user IDs from the query result map */
@@ -483,6 +483,13 @@ public class ApdServiceImpl implements ApdService {
       Handler<AsyncResult<JsonObject>> handler) {
 
     LOGGER.debug("Info : " + LOGGER.getName() + " : Request received");
+
+    if (user.getUserId().equals(NIL_UUID)) {
+      Response r = new ResponseBuilder().status(404).type(URN_MISSING_INFO)
+          .title(ERR_TITLE_NO_USER_PROFILE).detail(ERR_DETAIL_NO_USER_PROFILE).build();
+      handler.handle(Future.succeededFuture(r.toJson()));
+      return this;
+    }
 
     if (!user.getRoles().contains(Roles.TRUSTEE)) {
       Response resp = new ResponseBuilder().type(URN_INVALID_ROLE).title(ERR_TITLE_NOT_TRUSTEE)

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -123,7 +123,7 @@ public class Constants {
   public static final String CREATE_TOKEN_URL = "url";
   public static final String CREATE_TOKEN_CONSTRAINTS = "constraints";
   public static final String CREATE_TOKEN_CAT_ID = "cat_id";
-  public static final String CREATE_TOKEN_SESSIONID = "session_id";
+  public static final String CREATE_TOKEN_SESSIONID = "sessionId";
   public static final String CREATE_TOKEN_LINK = "link";
   public static final String CREATE_TOKEN_STATUS = "status";
   public static final String CREATE_TOKEN_SUCCESS = "success";


### PR DESCRIPTION
- Send 404 if a user with no user profile tries to create an APD
- Get distinct trustee IDs when setting admin policy when APD becomes active.
(Multiple policies were being set when multiple APDs belonging to same trustee
were set to active state)
- Change session ID key in JSON sent from callApd to createToken