### PR TITLE
Add configurable option for APD webclient to use HTTPS/HTTP

### DIFF
--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -81,6 +81,7 @@
       "id": "iudx.aaa.server.apd.ApdVerticle",
       "verticleInstances": 1,
       "required":["postgresOptions", "commonOptions"],
+      "webClientCheckSsl": true,
       "poolSize": "25"
     },
      {

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
 
   /* Config related */
   public static final String CONFIG_AUTH_URL = "authServerDomain";
+  public static final String CONFIG_WEBCLI_CHECKSSL = "webClientCheckSsl";
   public static final String DATABASE_IP = "databaseIP";
   public static final String DATABASE_PORT = "databasePort";
   public static final String DATABASE_NAME = "databaseName";


### PR DESCRIPTION
- By default, the web client will use HTTPS
- This option is meant to ease integration testing on localhost
- An APD can be bound to port 443 (since the web
client always communicates via that port) and not use HTTPS. When the
config of a localhost auth server is set to use HTTP (i.e. set to `false`),
 and `/etc/hosts` is modified, the auth server can connect to the APD
without adding self-signed certificates or any modification of the code.