### PR TITLE
Jenkins CI Updates for v3.5.0 pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,14 +105,14 @@ pipeline {
     stage('Push Image') {
       when{
         expression {
-          return env.GIT_BRANCH == 'origin/main';
+          return env.GIT_BRANCH == 'origin/v3.5.0';
         }
       }
       steps{
         script {
           docker.withRegistry( registryUri, registryCredential ) {
-            devImage.push("3.0-${env.GIT_HASH}")
-            deplImage.push("3.0-${env.GIT_HASH}")
+            devImage.push("3.5.0-${env.GIT_HASH}")
+            deplImage.push("3.5.0-${env.GIT_HASH}")
           }
         }
       }


### PR DESCRIPTION
Added a separate CI pipeline for branch v3.5.0 in Jenkins. Which will also build and push the image for any updates in this branch tagged with 3.5.0-{git commit hash}
- Changed branch condition and image tag for image push stage