### PR TITLE
Separate enum updation from APD_policy table creation in migration

### DIFF
--- a/src/main/resources/db/migration/V4__Add_Apd_policy_table.sql
+++ b/src/main/resources/db/migration/V4__Add_Apd_policy_table.sql
@@ -26,7 +26,3 @@ ALTER TABLE ONLY apd_policies
     ADD CONSTRAINT apd_policies_apd_id_fkey FOREIGN KEY (apd_id) REFERENCES apds(id);
 
 GRANT SELECT,INSERT,UPDATE ON TABLE apd_policies TO ${authUser};
-
--- Update resource_enum with apd type
-
-ALTER TYPE item_enum ADD VALUE 'APD' AFTER 'RESOURCE';

--- a/src/main/resources/db/migration/V5__Add_APD_to_resource_enum.sql
+++ b/src/main/resources/db/migration/V5__Add_APD_to_resource_enum.sql
@@ -1,0 +1,3 @@
+-- Update resource_enum with apd type
+
+ALTER TYPE item_enum ADD VALUE 'APD' AFTER 'RESOURCE';


### PR DESCRIPTION
- Error occured during migrating in production
- The `ALTER TYPE` command cannot be executed in a transaction in the pg version used on production
- Since this command was included in a migration that had commands that could be executed
in a transaction, flyway tried to run it in a transaction by default and threw
an error. Mixing of transaction and non-transaction commands is not allowed,
without including a special configuration value. (https://flywaydb.org/documentation/concepts/migrations.html#transactions)
- Hence, we separate out the `ALTER TYPE` command into a separate migration