### PR TITLE
Updated to refer configs archived for release 3.5.0 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
       post{
         failure{
           script{
-            sh 'mvn flyway:clean -Dflyway.configFiles=/home/ubuntu/configs/aaa-flyway.conf'
+            sh 'mvn flyway:clean -Dflyway.configFiles=/home/ubuntu/configs/3.5.0/aaa-flyway.conf'
           }
           cleanWs deleteDirs: true, disableDeferredWipeout: true, patterns: [[pattern: 'src/main/resources/db/migration/V?__Add_Integration_Test_data.sql', type: 'INCLUDE']]
         }
@@ -74,7 +74,7 @@ pipeline {
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
             sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/aaa/Newman/Integration_Test.postman_collection.json -e /home/ubuntu/configs/aaa-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/aaa/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/aaa/Newman/Integration_Test.postman_collection.json -e /home/ubuntu/configs/3.5.0/aaa-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/aaa/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             }
             runZapAttack()
           }
@@ -94,7 +94,7 @@ pipeline {
         }
         cleanup{
           script{
-            sh 'mvn flyway:clean -Dflyway.configFiles=/home/ubuntu/configs/aaa-flyway.conf'
+            sh 'mvn flyway:clean -Dflyway.configFiles=/home/ubuntu/configs/3.5.0/aaa-flyway.conf'
             sh 'docker-compose -f docker-compose-test.yml down --remove-orphans'
           }
           cleanWs deleteDirs: true, disableDeferredWipeout: true, patterns: [[pattern: 'src/main/resources/db/migration/V?__Add_Integration_Test_data.sql', type: 'INCLUDE']]

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,8 +10,8 @@ services:
       - LOG_LEVEL=INFO
       - AUTH_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/aaa-config-test.json:/usr/share/app/configs/config-test.json
-      - /home/ubuntu/configs/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/aaa-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/3.5.0/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./src/:/usr/share/app/src
       - ${WORKSPACE}:/tmp/test
@@ -26,9 +26,9 @@ services:
       - LOG_LEVEL=INFO
       - AUTH_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/aaa-config-integ.json:/usr/share/app/configs/config-dev.json
-      - /home/ubuntu/configs/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
-      - /home/ubuntu/configs/aaa-flyway.conf:/usr/share/app/flyway.conf
+      - /home/ubuntu/configs/3.5.0/aaa-config-integ.json:/usr/share/app/configs/config-dev.json
+      - /home/ubuntu/configs/3.5.0/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/aaa-flyway.conf:/usr/share/app/flyway.conf
       - ./docs/:/usr/share/app/docs
       - ./src/:/usr/share/app/src
     command: bash -c "mvn clean compile exec:java@aaa-server"

--- a/docker/runIntegTests.sh
+++ b/docker/runIntegTests.sh
@@ -2,5 +2,5 @@
 
 files_present=$(ls ./src/main/resources/db/migration | wc -l)
 new_version=$(echo "$files_present+1" | bc)
-cp /home/ubuntu/configs/aaa-Add_Integration_Test_data.sql ./src/main/resources/db/migration/V${new_version}__Add_Integration_Test_data.sql
-mvn flyway:migrate -Dflyway.configFiles=/home/ubuntu/configs/aaa-flyway.conf
+cp /home/ubuntu/configs/3.5.0/aaa-Add_Integration_Test_data.sql ./src/main/resources/db/migration/V${new_version}__Add_Integration_Test_data.sql
+mvn flyway:migrate -Dflyway.configFiles=/home/ubuntu/configs/3.5.0/aaa-flyway.conf


### PR DESCRIPTION
Until now the same config files were being used in all the pipelines (master/PR/3.5.0). But since testing the v4.0 components (master and PR CI) might require changes in the config files, it could end up affecting v3.5.0 CI pipelines.
To avoid this, archiving the current configs for the 3.5.0 pipelines separately and updated references in the CI tests to refer to those.