### PR TITLE
Update JaCoCo exclusions for unit test coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
           thresholds: [ skipped(failureThreshold: '0'), failed(failureThreshold: '0') ],
           tools: [ JUnit(pattern: 'target/surefire-reports/*.xml') ]
         )
-        jacoco classPattern: 'target/classes', execPattern: 'target/jacoco.exec', sourcePattern: 'src/main/java', exclusionPattern:'iudx/aaa/server/apiserver/ApiServerVerticle.class,**/*VertxEBProxy.class,**/Constants.class,**/*VertxProxyHandler.class,**/*Verticle.class,iudx/aaa/server/deploy/*.class'
+        jacoco classPattern: 'target/classes', execPattern: 'target/jacoco.exec', sourcePattern: 'src/main/java', exclusionPattern:'**/*VertxEBProxy.class,**/Constants.class,**/*VertxProxyHandler.class,**/*Verticle.class,iudx/aaa/server/deploy/*.class,iudx/aaa/server/registration/KcAdmin.class,iudx/aaa/server/apiserver/*,iudx/aaa/server/apiserver/util/*'
       }
       post{
         failure{

--- a/pom.xml
+++ b/pom.xml
@@ -265,13 +265,19 @@
 					<excludes>
 						<!-- classes are excluded since they are not testable or don't add 
 							any value if test cases are written. -->
-						<!-- ApiServerVerticle testing is covered in integration for now. -->
-						<exclude>iudx/aaa/server/apiserver/ApiServerVerticle.class</exclude>
 						<exclude>**/*VertxEBProxy.class</exclude>
 						<exclude>**/Constants.class</exclude>
 						<exclude>**/*VertxProxyHandler.class</exclude>
 						<exclude>**/*Verticle.class</exclude>
 						<exclude>iudx/aaa/server/deploy/*.class</exclude>
+						<!-- KcAdmin cannot be tested in unit tests -->
+						<exclude>iudx/aaa/server/registration/KcAdmin.class</exclude>
+                        <!-- Omit apiserver -->
+                        <!-- Contains ApiServerVerticle, data objects and main classes -->
+                        <exclude>iudx/aaa/server/apiserver/*</exclude>
+                        <!-- Omit apiserver/util -->
+                        <!-- Contains OIDC, client creds authn and auth delegate authn -->
+                        <exclude>iudx/aaa/server/apiserver/util/*</exclude>
 					</excludes>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
- Added /apiserver/* which currently has
	- ApiServerVerticle : not being tested in unit tests as of now
	- Data Objects
	- The data object converters that vert.x generates
	- User class
	- Enums
- Added /apiserver/util/*
	- Has ComposeException, Urn
	- Has the OIDC, client credential and auth delegate route handlers
- Added KcAdmin
	- Can't be tested in unit tests