### PR TITLE
Fixes to update notification API (to 3.5.0)

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/NotifRequestStatus.java
+++ b/src/main/java/iudx/aaa/server/apiserver/NotifRequestStatus.java
@@ -1,0 +1,9 @@
+package iudx.aaa.server.apiserver;
+
+/**
+ * Enum that defines valid status a notification request can be in. Maps to
+ * <i>acc_reqs_status_enum</i> in schema.
+ */
+public enum NotifRequestStatus {
+  PENDING, APPROVED, REJECTED;
+}

--- a/src/main/java/iudx/aaa/server/apiserver/UpdatePolicyNotification.java
+++ b/src/main/java/iudx/aaa/server/apiserver/UpdatePolicyNotification.java
@@ -12,7 +12,7 @@ import static iudx.aaa.server.apiserver.util.Constants.*;
 public class UpdatePolicyNotification {
 
   UUID requestId;
-  RoleStatus status;
+  NotifRequestStatus status;
   String expiryDuration;
   JsonObject constraints;
   
@@ -42,11 +42,11 @@ public class UpdatePolicyNotification {
     this.requestId = UUID.fromString(requestId);
   }
 
-  public RoleStatus getStatus() {
+  public NotifRequestStatus getStatus() {
     return status;
   }
 
-  public void setStatus(RoleStatus status) {
+  public void setStatus(NotifRequestStatus status) {
     this.status = status;
   }
 

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -350,7 +350,8 @@ public class Constants {
       "SELECT ar.id AS \"requestId\", pol.id AS \"policyId\" FROM "
           + "access_requests ar "
           + "LEFT JOIN policies pol ON ar.user_id = pol.user_id AND ar.item_id = pol.item_id AND ar.owner_id = pol.owner_id \n"
-          + "WHERE pol.user_id= $1::UUID AND pol.item_id = $2::UUID AND ar.owner_id = $3::UUID AND pol.status = 'ACTIVE'";
+          + "WHERE pol.user_id= $1::UUID AND pol.item_id = $2::UUID AND ar.owner_id = $3::UUID AND ar.id = $4::UUID"
+          + " AND pol.status = 'ACTIVE'";
 
   public static final String INSERT_NOTIF_APPROVED_ID =
       "INSERT INTO approved_access_requests(request_id,policy_id,created_at,updated_at) "

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -1981,7 +1981,7 @@ public class PolicyServiceImpl implements PolicyService {
                   each.put(EXPIRYTIME, interval.getEnd().toString());
                   each.put(ITEMID, idMap.get(UUID.fromString(itemId)));
                   selectPolicy
-                      .add(Tuple.of(each.getString(USERID), itemId, each.getString(OWNERID)));
+                      .add(Tuple.of(each.getString(USERID), itemId, each.getString(OWNERID), each.getString(ID)));
 
                   return each;
                 }).collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -2018,7 +2018,7 @@ public class PolicyServiceImpl implements PolicyService {
                   List<CreatePolicyRequest> createPolicyArray =
                       CreatePolicyRequest.jsonArrayToList(approvedReq);
 
-                  createPolicy(createPolicyArray, user, new JsonObject(), createHandler -> {
+                  createPolicy(createPolicyArray, user, data, createHandler -> {
                     if (createHandler.failed()) {
                       handler.handle(Future.succeededFuture(createHandler.result()));
                       return;

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -11,6 +11,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.data.Interval;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Tuple;
 import iudx.aaa.server.apd.ApdService;
@@ -1912,216 +1913,222 @@ public class PolicyServiceImpl implements PolicyService {
             .flatMap(result -> conn.preparedQuery(SEL_NOTIF_REQ_ID).collecting(notifRequestCollect)
                 .execute(tup).map(res -> res.value())));
 
-    policyRequestData.onComplete(dbHandler -> {
-      if (dbHandler.failed()) {
-        LOGGER.error(LOG_DB_ERROR + " {}",
-            dbHandler.cause() == null ? dbHandler.result() : dbHandler.cause().getMessage());
-        handler.handle(Future.failedFuture(INTERNALERROR));
+    Future<JsonArray> createPolicyArray = policyRequestData.compose(dbHandler -> {
+
+      if (dbHandler.size() != request.size()) {
+        LOGGER.debug("Info: {}", REQ_ID_ALREADY_NOT_EXISTS);
+
+        Response resp = new ResponseBuilder().status(404).type(URN_INVALID_INPUT)
+            .title(SUCC_NOTIF_REQ).detail(REQ_ID_ALREADY_NOT_EXISTS).build();
+        return Future.failedFuture(new ComposeException(resp));
+      }
+
+      /*
+       * We can do this in the previous query, but since there is a separate response for 'request
+       * ID already processed', we do it here
+       */
+      Boolean nonPendingReqIds = dbHandler.stream()
+          .anyMatch(obj -> !obj.getString("status").equals(RoleStatus.PENDING.name()));
+
+      if (nonPendingReqIds) {
+        return Future.failedFuture(
+            new ComposeException(400, URN_INVALID_INPUT, SUCC_NOTIF_REQ, REQ_ID_ALREADY_PROCESSED));
+      }
+
+      List<JsonObject> notifReqlist = dbHandler;
+      JsonArray createPolicyArr = new JsonArray();
+
+      notifReqlist.forEach(each -> {
+        UUID requestId = UUID.fromString(each.getString(ID));
+        JsonObject requestJson = requestMap.get(requestId);
+        if (requestJson != null) {
+          JsonObject temp = each.copy().mergeIn(requestJson, Boolean.TRUE);
+          createPolicyArr.add(temp);
+        }
+      });
+
+      return Future.succeededFuture(createPolicyArr);
+    });
+
+    Future<Map<UUID, String>> getItemIdName = createPolicyArray.compose(createPolicyArr -> {
+      List<UUID> itemIds = createPolicyArr.stream().map(JsonObject.class::cast)
+          .map(each -> UUID.fromString(each.getString(ITEMID))).collect(Collectors.toList());
+
+      Collector<Row, ?, Map<UUID, String>> collectItemName =
+          Collectors.toMap(row -> row.getUUID(ID), row -> row.getString(URL));
+
+      return pool
+          .withTransaction(conn -> conn.preparedQuery(SEL_NOTIF_ITEM_ID).collecting(collectItemName)
+              .execute(Tuple.of(itemIds.toArray(UUID[]::new))).map(res -> res.value()));
+    });
+
+    Promise<JsonArray> approvedRequestArray = Promise.promise();
+    Promise<JsonArray> rejectedRequestArray = Promise.promise();
+    Promise<List<Tuple>> approvedRequestTupList = Promise.promise();
+    Promise<List<Tuple>> rejectedRequestTupList = Promise.promise();
+
+    Future<Void> approvedRejectedQueryData = getItemIdName.compose(idMap -> {
+
+      LocalDateTime start = LocalDateTime.now();
+      List<Tuple> selectPolicy = new ArrayList<>();
+      JsonArray resArr = new JsonArray();
+
+      JsonArray approvedReq = createPolicyArray.result().stream().map(JsonObject.class::cast)
+          .filter(each -> each.getString(STATUS).equals(RoleStatus.APPROVED.name())).map(each -> {
+            String expiry = each.getString("expiryDuration");
+            String itemId = each.getString(ITEMID);
+
+            org.joda.time.Interval interval = org.joda.time.Interval.parse(start + "/" + expiry);
+            each.put(EXPIRYTIME, interval.getEnd().toString());
+            each.put(ITEMID, idMap.get(UUID.fromString(itemId)));
+            selectPolicy.add(Tuple.of(each.getString(USERID), itemId, each.getString(OWNERID),
+                each.getString(ID)));
+
+            return each;
+          }).collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));
+
+      approvedRequestArray.complete(approvedReq);
+      approvedRequestTupList.complete(selectPolicy);
+
+      List<Tuple> updateRejectedReq = createPolicyArray.result().stream()
+          .map(JsonObject.class::cast)
+          .filter(each -> each.getString(STATUS).equals(RoleStatus.REJECTED.name())).map(each -> {
+            UUID requestId = UUID.fromString(each.getString("requestId"));
+            String status = each.getString(STATUS);
+
+            String itemId = each.getString(ITEMID);
+            each.put(ITEMID, idMap.get(UUID.fromString(itemId)));
+            each.put(STATUS, status.toLowerCase());
+            resArr.add(each);
+            return Tuple.of(requestId, status);
+          }).collect(Collectors.toList());
+
+      rejectedRequestTupList.complete(updateRejectedReq);
+      rejectedRequestArray.complete(resArr);
+      return Future.succeededFuture();
+    });
+
+    Future<JsonObject> userDetails = approvedRejectedQueryData.compose(res -> {
+
+      List<String> ownerIds = createPolicyArray.result().stream().map(JsonObject.class::cast)
+          .map(each -> each.getString(OWNERID)).collect(Collectors.toList());
+
+      List<String> ids = new ArrayList<String>();
+      ids.add(user.getUserId());
+      ids.addAll(ownerIds);
+
+      Promise<JsonObject> p = Promise.promise();
+      registrationService.getUserDetails(ids, p);
+      return p.future();
+    });
+
+    /*
+     * We create 2 functional interfaces, one for updating approved requests, the other for updating
+     * rejected requests. The SqlConnection passed is created using withTransaction so that the
+     * rollback (if it occurs) will affect both approve and reject operations. We use the functional
+     * interfaces since approving and rejecting requests have different queries, and we need to be
+     * able to rollback both queries in case any one fails. May be possible to use
+     * pool.getConnection(), but not sure if a rollback is triggered when a future fails somewhere.
+     */
+    Function<SqlConnection, Future<Void>> updateApprovedRequests = (SqlConnection conn) -> {
+      JsonArray approvedReq = approvedRequestArray.future().result();
+
+      if (approvedReq.size() == 0) {
+        return Future.succeededFuture();
+      }
+
+      List<UpdatePolicyNotification> updateReq =
+          UpdatePolicyNotification.jsonArrayToList(approvedReq);
+
+      Future<List<Tuple>> updateApprovedTup = mapTupleUpdate(updateReq);
+
+      List<CreatePolicyRequest> createPolicyReqArray =
+          CreatePolicyRequest.jsonArrayToList(approvedRequestArray.future().result());
+
+      Collector<Row, ?, List<Tuple>> policyCollector = Collectors.mapping(
+          row -> Tuple.of(row.getUUID("requestId"), row.getUUID("policyId")), Collectors.toList());
+
+      return updateApprovedTup.compose(mapper -> conn.preparedQuery(UPDATE_NOTIF_REQ_APPROVED)
+          .executeBatch(mapper).compose(updateSuccHandler -> {
+            Promise<JsonObject> createPolicyRes = Promise.promise();
+            createPolicy(createPolicyReqArray, user, data, createPolicyRes);
+            return createPolicyRes.future();
+          }).compose(createdHandler -> {
+            JsonObject result = createdHandler;
+            if (URN_SUCCESS.toString().equalsIgnoreCase(result.getString(TYPE))) {
+              /* NOTE: If a failure occurs here, the policy creation cannot be rolled back */
+              return conn.preparedQuery(SEL_NOTIF_POLICY_ID).collecting(policyCollector)
+                  .executeBatch(approvedRequestTupList.future().result())
+                  .flatMap(insert -> conn.preparedQuery(INSERT_NOTIF_APPROVED_ID)
+                      .executeBatch(insert.value()).mapEmpty());
+            } else {
+              return Future.failedFuture(new ComposeException(400, URN_INVALID_INPUT,
+                  SUCC_NOTIF_REQ, result.getString(TITLE)));
+            }
+          }));
+    };
+
+    Function<SqlConnection, Future<Void>> updateRejectedRequests = (SqlConnection conn) -> {
+      List<Tuple> updateRejectedTup = rejectedRequestTupList.future().result();
+
+      if (updateRejectedTup.size() == 0) {
+        return Future.succeededFuture();
+      }
+
+      return conn.preparedQuery(UPDATE_NOTIF_REQ_REJECTED).executeBatch(updateRejectedTup)
+          .mapEmpty();
+    };
+
+    /*
+     * Open the transaction using withTransaction and pass the conn object to the update approved
+     * and rejected request functions
+     */
+    Future<Void> updatedRequests = userDetails.compose(x -> {
+      return pool.withTransaction(conn -> updateRejectedRequests.apply(conn)
+          .compose(res -> updateApprovedRequests.apply(conn)));
+    });
+
+    updatedRequests.compose(result -> {
+      Map<String, JsonObject> userInfo = jsonObjectToMap.apply(userDetails.result());
+
+      JsonObject userJson1 = userInfo.get(user.getUserId());
+
+      List<String> ownerIds = createPolicyArray.result().stream().map(JsonObject.class::cast)
+          .map(each -> each.getString(OWNERID)).collect(Collectors.toList());
+
+      JsonArray results = new JsonArray();
+      JsonArray resArr = rejectedRequestArray.future().result();
+      resArr.addAll(approvedRequestArray.future().result());
+      for (int i = 0; i < resArr.size(); i++) {
+        JsonObject requestJson = resArr.getJsonObject(i);
+
+        requestJson.remove(EXPIRYTIME);
+        requestJson.remove(USERID);
+        requestJson.remove(OWNERID);
+        requestJson.remove(ID);
+        requestJson.put(STATUS, requestJson.getString(STATUS).toLowerCase());
+        requestJson.put(ITEMTYPE, requestJson.getString(ITEMTYPE).toLowerCase());
+
+        JsonObject eachJson = requestJson.put(USER_DETAILS, userJson1).put(OWNER_DETAILS,
+            userInfo.get(ownerIds.get(i)));
+
+        results.add(eachJson);
+      }
+      return Future.succeededFuture(results);
+    }).onSuccess(results -> {
+      LOGGER.info("Success: {}; {}", SUCC_NOTIF_REQ, SUCC_UPDATE_NOTIF_REQ);
+      Response res = new Response.ResponseBuilder().type(URN_SUCCESS).title(SUCC_UPDATE_NOTIF_REQ)
+          .status(200).arrayResults(results).build();
+      handler.handle(Future.succeededFuture(res.toJson()));
+      return;
+    }).onFailure(obj -> {
+      if (obj instanceof ComposeException) {
+        ComposeException e = (ComposeException) obj;
+        handler.handle(Future.succeededFuture(e.getResponse().toJson()));
         return;
       }
-
-      if (dbHandler.succeeded()) {
-        if (dbHandler.result().size() != request.size()) {
-          LOGGER.debug("Info: {}", REQ_ID_ALREADY_NOT_EXISTS);
-
-          Response resp = new ResponseBuilder().status(404).type(URN_INVALID_INPUT)
-              .title(SUCC_NOTIF_REQ).detail(REQ_ID_ALREADY_NOT_EXISTS).build();
-          handler.handle(Future.succeededFuture(resp.toJson()));
-          return;
-        }
-
-        List<JsonObject> notifReqlist = dbHandler.result();
-        JsonArray createPolicyArr = new JsonArray();
-
-        notifReqlist.forEach(each -> {
-          UUID requestId = UUID.fromString(each.getString(ID));
-          JsonObject requestJson = requestMap.get(requestId);
-          if (requestJson != null) {
-            JsonObject temp = each.copy().mergeIn(requestJson, Boolean.TRUE);
-            createPolicyArr.add(temp);
-          }
-        });
-
-        List<String> ownerIds = createPolicyArr.stream().map(JsonObject.class::cast)
-            .map(each -> each.getString(OWNERID)).collect(Collectors.toList());
-
-        List<UUID> itemIds = createPolicyArr.stream().map(JsonObject.class::cast)
-            .map(each -> UUID.fromString(each.getString(ITEMID))).collect(Collectors.toList());
-
-        Collector<Row, ?, Map<UUID, String>> collectItemName =
-            Collectors.toMap(row -> row.getUUID(ID), row -> row.getString(URL));
-
-        Future<Map<UUID, String>> getItemIdName = pool.withTransaction(
-            conn -> conn.preparedQuery(SEL_NOTIF_ITEM_ID).collecting(collectItemName)
-                .execute(Tuple.of(itemIds.toArray(UUID[]::new))).map(res -> res.value()));
-
-        getItemIdName.onComplete(getHandler -> {
-          if (getHandler.failed()) {
-            LOGGER.error(LOG_DB_ERROR + " {}", getHandler.cause().getMessage());
-            handler.handle(Future.failedFuture(INTERNALERROR));
-            return;
-          }
-
-          if (getHandler.succeeded()) {
-
-            Map<UUID, String> idMap = getHandler.result();
-
-            LocalDateTime start = LocalDateTime.now();
-            List<Tuple> selectPolicy = new ArrayList<>();
-            JsonArray resArr = new JsonArray();
-
-            JsonArray approvedReq = createPolicyArr.stream().map(JsonObject.class::cast)
-                .filter(each -> each.getString(STATUS).equals(RoleStatus.APPROVED.name()))
-                .map(each -> {
-                  String expiry = each.getString("expiryDuration");
-                  String itemId = each.getString(ITEMID);
-
-                  org.joda.time.Interval interval =
-                      org.joda.time.Interval.parse(start + "/" + expiry);
-                  each.put(EXPIRYTIME, interval.getEnd().toString());
-                  each.put(ITEMID, idMap.get(UUID.fromString(itemId)));
-                  selectPolicy
-                      .add(Tuple.of(each.getString(USERID), itemId, each.getString(OWNERID), each.getString(ID)));
-
-                  return each;
-                }).collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));
-
-            List<Tuple> updateRejectedReq = createPolicyArr.stream().map(JsonObject.class::cast)
-                .filter(each -> each.getString(STATUS).equals(RoleStatus.REJECTED.name()))
-                .map(each -> {
-                  UUID requestId = UUID.fromString(each.getString("requestId"));
-                  String status = each.getString(STATUS);
-
-                  String itemId = each.getString(ITEMID);
-                  each.put(ITEMID, idMap.get(UUID.fromString(itemId)));
-                  each.put(STATUS, status.toLowerCase());
-                  resArr.add(each);
-                  return Tuple.of(requestId, status);
-                }).collect(Collectors.toList());
-
-            Future<Object> updateDb = Future.future(futureHandler -> {
-              if (!approvedReq.isEmpty()) {
-                List<UpdatePolicyNotification> updateReq =
-                    UpdatePolicyNotification.jsonArrayToList(approvedReq);
-                Future<List<Tuple>> updateTuple = mapTupleUpdate(updateReq);
-                updateTuple.compose(mapper -> {
-                  return pool.withTransaction(conn -> conn.preparedQuery(UPDATE_NOTIF_REQ_APPROVED)
-                      .executeBatch(mapper).map(res -> res.value()));
-                }).onFailure(updateFailHandler -> {
-                  futureHandler.fail(updateFailHandler.getCause());
-                  return;
-                }).onSuccess(updateSuccHandler -> {
-                  if (updateSuccHandler.rowCount() == 0) {
-                    futureHandler.fail(REQ_ID_ALREADY_PROCESSED);
-                    return;
-                  }
-                  List<CreatePolicyRequest> createPolicyArray =
-                      CreatePolicyRequest.jsonArrayToList(approvedReq);
-
-                  createPolicy(createPolicyArray, user, data, createHandler -> {
-                    if (createHandler.failed()) {
-                      handler.handle(Future.succeededFuture(createHandler.result()));
-                      return;
-                    }
-
-                    if (createHandler.succeeded()) {
-                      JsonObject result = createHandler.result();
-                      if (URN_SUCCESS.toString().equalsIgnoreCase(result.getString(TYPE))) {
-
-                        Collector<Row, ?, List<Tuple>> policyCollector = Collectors.mapping(
-                            row -> Tuple.of(row.getUUID("requestId"), row.getUUID("policyId")),
-                            Collectors.toList());
-
-                        Future<Object> insertQuery =
-                            pool.withTransaction(conn -> conn.preparedQuery(SEL_NOTIF_POLICY_ID)
-                                .collecting(policyCollector).executeBatch(selectPolicy)
-                                .flatMap(insert -> conn.preparedQuery(INSERT_NOTIF_APPROVED_ID)
-                                    .executeBatch(insert.value()).map(res -> res.value())));
-
-                        futureHandler.complete(insertQuery);
-                        return;
-                      } else {
-                        handler.handle(Future.succeededFuture(createHandler.result()));
-                      }
-                    }
-                  });
-                });
-              } else if (!updateRejectedReq.isEmpty()) {
-                Future<Integer> updateRejected =
-                    pool.withTransaction(conn -> conn.preparedQuery(UPDATE_NOTIF_REQ_REJECTED)
-                        .executeBatch(updateRejectedReq).map(res -> res.value().rowCount()));
-
-                updateRejected.onComplete(comHandler -> {
-                  if (comHandler.succeeded() && comHandler.result() == 0) {
-                    futureHandler.fail(REQ_ID_ALREADY_PROCESSED);
-                  } else {
-                    futureHandler.complete(updateRejected.result());
-                  }
-                });
-              }
-            });
-
-            updateDb.onComplete(updateHandler -> {
-              if (updateHandler.failed()) {
-                String msg = updateHandler.cause().getMessage();
-                LOGGER.error("Fail: {}", msg);
-                if (msg.contains(INTERNALERROR)) {
-                  handler.handle(Future.failedFuture(updateHandler.cause().getMessage()));
-                } else {
-                  Response res = new Response.ResponseBuilder().type(URN_INVALID_INPUT)
-                      .title(SUCC_NOTIF_REQ).detail(msg).status(400).build();
-                  handler.handle(Future.succeededFuture(res.toJson()));
-                }
-                return;
-
-              } else if (updateHandler.succeeded()) {
-
-                List<String> ids = new ArrayList<>();
-                ids.add(user.getUserId());
-                ids.addAll(ownerIds);
-
-                registrationService.getUserDetails(ids, userHandler -> {
-                  if (userHandler.failed()) {
-                    LOGGER.error("Fail: Registration failure; " + userHandler.cause());
-                    handler.handle(Future.failedFuture(INTERNALERROR));
-                    return;
-                  }
-
-                  if (userHandler.succeeded()) {
-                    Map<String, JsonObject> userInfo = jsonObjectToMap.apply(userHandler.result());
-
-                    JsonObject userJson1 = userInfo.get(user.getUserId());
-
-                    JsonArray results = new JsonArray();
-                    resArr.addAll(approvedReq);
-                    for (int i = 0; i < resArr.size(); i++) {
-                      JsonObject requestJson = resArr.getJsonObject(i);
-
-                      requestJson.remove(EXPIRYTIME);
-                      requestJson.remove(USERID);
-                      requestJson.remove(OWNERID);
-                      requestJson.remove(ID);
-                      requestJson.put(STATUS, requestJson.getString(STATUS).toLowerCase());
-                      requestJson.put(ITEMTYPE, requestJson.getString(ITEMTYPE).toLowerCase());
-
-                      JsonObject eachJson = requestJson.put(USER_DETAILS, userJson1)
-                          .put(OWNER_DETAILS, userInfo.get(ownerIds.get(i)));
-
-                      results.add(eachJson);
-                    }
-
-                    LOGGER.info("Success: {}; {}", SUCC_NOTIF_REQ, SUCC_UPDATE_NOTIF_REQ);
-                    Response res = new Response.ResponseBuilder().type(URN_SUCCESS)
-                        .title(SUCC_UPDATE_NOTIF_REQ).status(200).arrayResults(results).build();
-                    handler.handle(Future.succeededFuture(res.toJson()));
-                    return;
-                  }
-                });
-              }
-            });
-          }
-        });
-      }
+      LOGGER.error(obj.getMessage());
+      handler.handle(Future.failedFuture(INTERNALERROR));
     });
     return this;
   }

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -2104,6 +2104,9 @@ public class PolicyServiceImpl implements PolicyService {
       for (int i = 0; i < resArr.size(); i++) {
         JsonObject requestJson = resArr.getJsonObject(i);
 
+        LOGGER.info("Updated status of request ID {} to {}", requestJson.getString(ID),
+            requestJson.getString(STATUS).toUpperCase());
+
         requestJson.remove(EXPIRYTIME);
         requestJson.remove(USERID);
         requestJson.remove(OWNERID);

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -20,10 +20,10 @@ import iudx.aaa.server.apiserver.CreateDelegationRequest;
 import iudx.aaa.server.apiserver.CreatePolicyNotification;
 import iudx.aaa.server.apiserver.CreatePolicyRequest;
 import iudx.aaa.server.apiserver.DeleteDelegationRequest;
+import iudx.aaa.server.apiserver.NotifRequestStatus;
 import iudx.aaa.server.apiserver.ResourceObj;
 import iudx.aaa.server.apiserver.Response;
 import iudx.aaa.server.apiserver.Response.ResponseBuilder;
-import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.UpdatePolicyNotification;
 import iudx.aaa.server.apiserver.User;
@@ -1928,7 +1928,7 @@ public class PolicyServiceImpl implements PolicyService {
        * ID already processed', we do it here
        */
       Boolean nonPendingReqIds = dbHandler.stream()
-          .anyMatch(obj -> !obj.getString("status").equals(RoleStatus.PENDING.name()));
+          .anyMatch(obj -> !obj.getString("status").equals(NotifRequestStatus.PENDING.name()));
 
       if (nonPendingReqIds) {
         return Future.failedFuture(
@@ -1974,7 +1974,8 @@ public class PolicyServiceImpl implements PolicyService {
       JsonArray resArr = new JsonArray();
 
       JsonArray approvedReq = createPolicyArray.result().stream().map(JsonObject.class::cast)
-          .filter(each -> each.getString(STATUS).equals(RoleStatus.APPROVED.name())).map(each -> {
+          .filter(each -> each.getString(STATUS).equals(NotifRequestStatus.APPROVED.name()))
+          .map(each -> {
             String expiry = each.getString("expiryDuration");
             String itemId = each.getString(ITEMID);
 
@@ -1992,7 +1993,8 @@ public class PolicyServiceImpl implements PolicyService {
 
       List<Tuple> updateRejectedReq = createPolicyArray.result().stream()
           .map(JsonObject.class::cast)
-          .filter(each -> each.getString(STATUS).equals(RoleStatus.REJECTED.name())).map(each -> {
+          .filter(each -> each.getString(STATUS).equals(NotifRequestStatus.REJECTED.name()))
+          .map(each -> {
             UUID requestId = UUID.fromString(each.getString("requestId"));
             String status = each.getString(STATUS);
 
@@ -2366,7 +2368,7 @@ public class PolicyServiceImpl implements PolicyService {
         UUID itemId = resource.getId();
         UUID ownerId = resource.getOwnerId();
 
-        String status = RoleStatus.PENDING.name();
+        String status = NotifRequestStatus.PENDING.name();
         String itemType = each.getItemType().toUpperCase();
 
         Duration duration = DatatypeFactory.newInstance().newDuration(each.getExpiryDuration());
@@ -2447,7 +2449,7 @@ public class PolicyServiceImpl implements PolicyService {
       UUID userId = tuples.get(i).getUUID(0);
       UUID itemId = tuples.get(i).getUUID(1);
       UUID ownerId = tuples.get(i).getUUID(3);
-      String status = RoleStatus.PENDING.name();
+      String status = NotifRequestStatus.PENDING.name();
       selectTuples.add(Tuple.of(userId, itemId, ownerId, status));
     }
     pool.withConnection(


### PR DESCRIPTION
- 0faab68 fixes issue #183 
- 2afdd595900f5db34abf7f65ab4f36d889487a98 fixes #181 
- e6777423536a772069cd6d29e078ce5a94db39b6 fixes #180 and #182 

Major Changes
------------
- Changed query for adding into the `approved_access_requests` table to specifically insert to a particular request ID
- Make the async flow use a compose chain
- Make update approved and rejected operations in the same transaction