### PR TITLE
Bug-fix: Check item ID contains minimum amount of slashes when verifying policy (to main)

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -105,6 +105,7 @@ public class Constants {
   public static final String NO_AUTH_POLICY = "No auth policy for user";
   public static final String NO_AUTH_TRUSTEE_POLICY = "No auth policy for user by trustee";
   public static final String INCORRECT_ITEM_TYPE = "incorrect item type";
+  public static final String INCORRECT_ITEM_ID = "incorrect item ID";
   public static final String UNAUTHORIZED = "Not allowed to create policies for resource";
   public static final String PROVIDER_NOT_REGISTERED = "Provider not a registered user";
   public static final String DUPLICATE_POLICY = "Policy already exists:";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -1344,6 +1344,19 @@ public class PolicyServiceImpl implements PolicyService {
 
     String[] itemSplit = itemId.split("/");
 
+    if (itemSplit.length < 4 && (itemType.equals(itemTypes.RESOURCE.toString())
+        || itemType.equals(itemTypes.RESOURCE_GROUP.toString()))) {
+        Response r =
+            new ResponseBuilder()
+                .status(403)
+                .type(URN_INVALID_INPUT)
+                .title(INVALID_POLICY)
+                .detail(INCORRECT_ITEM_ID)
+                .build();
+        handler.handle(Future.failedFuture(new ComposeException(r)));
+        return this;
+    }
+    
     String emailHash = itemSplit[0] + "/" + itemSplit[1];
     Future<String> getRoles =
         pool.withConnection(

--- a/src/test/java/iudx/aaa/server/policy/TestRequest.java
+++ b/src/test/java/iudx/aaa/server/policy/TestRequest.java
@@ -25,6 +25,13 @@ public class TestRequest {
           .put("role", "consumer")
           .put("userId", "d1262b13-1cbe-4b66-a9b2-96df86437683");
 
+  public static JsonObject invalidItemId =
+      new JsonObject()
+          .put("itemId", "rs.iudx.io")
+          .put("itemType", "resource_group")
+          .put("role", "consumer")
+          .put("userId", "d1262b13-1cbe-4b66-a9b2-96df86437683");
+
   public static JsonObject consumerVerification =
       new JsonObject()
           .put(

--- a/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static iudx.aaa.server.policy.Constants.INVALID_ROLE;
+import static iudx.aaa.server.policy.Constants.INCORRECT_ITEM_ID;
 import static iudx.aaa.server.policy.Constants.NO_ADMIN_POLICY;
 import static iudx.aaa.server.policy.Constants.REGISTRATION_SERVICE_ADDRESS;
 import static iudx.aaa.server.policy.Constants.STATUS;
@@ -35,6 +36,7 @@ import static iudx.aaa.server.policy.TestRequest.NoCataloguePolicy;
 import static iudx.aaa.server.policy.TestRequest.NoCatalogueProviderPolicy;
 import static iudx.aaa.server.policy.TestRequest.consumerVerification;
 import static iudx.aaa.server.policy.TestRequest.invalidDelegate;
+import static iudx.aaa.server.policy.TestRequest.invalidItemId;
 import static iudx.aaa.server.policy.TestRequest.roleFailure;
 import static iudx.aaa.server.policy.TestRequest.validDelegateVerification;
 import static iudx.aaa.server.policy.TestRequest.validProviderCat;
@@ -147,6 +149,21 @@ public class VerifyPolicyTest {
                     () -> {
                       ComposeException exp = (ComposeException) response;
                       assertEquals(INVALID_ROLE, exp.getResponse().getDetail());
+                      testContext.completeNow();
+                    })));
+  }
+
+  @Test
+  @DisplayName("Invalid item ID - sending URL instead of resource")
+  void invalidItemId(VertxTestContext testContext) {
+    policyService.verifyPolicy(
+        invalidItemId,
+        testContext.failing(
+            response ->
+                testContext.verify(
+                    () -> {
+                      ComposeException exp = (ComposeException) response;
+                      assertEquals(INCORRECT_ITEM_ID, exp.getResponse().getDetail());
                       testContext.completeNow();
                     })));
   }


### PR DESCRIPTION
- resource group and resource items must have at least 3 slashes
- added unit test