### PR TITLE
Add X-Content-Type-Options header to API response (to 3.5)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
         always{
           node('master') {
             script{
-              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 27
+              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 2
             }  
             publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/aaa/Newman/report/', reportFiles: 'report.html', reportName: 'HTML Report', reportTitles: '', reportName: 'Integration Test Report'])
           }

--- a/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
@@ -888,12 +888,14 @@ public class ApiServerVerticle extends AbstractVerticle {
     int status = msg.getInteger(STATUS, 400);
     msg.remove(STATUS);
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+    response.putHeader(HEADER_X_CONTENT_TYPE_OPTIONS, X_CONTENT_TYPE_OPTIONS_NOSNIFF);
     return response.setStatusCode(status).end(msg.toString());
   }
 
   private Future<Void> processResponse(HttpServerResponse response, String msg) {
     Response rs = new ResponseBuilder().title(INTERNAL_SVR_ERR).detail(msg).build();
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+    response.putHeader(HEADER_X_CONTENT_TYPE_OPTIONS, X_CONTENT_TYPE_OPTIONS_NOSNIFF);
     return response.setStatusCode(500).end(rs.toJsonString());
   }
 

--- a/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
@@ -12,11 +12,13 @@ public class Constants {
   public static final String HEADER_ACCEPT = "Accept";
   public static final String HEADER_CONTENT_LENGTH = "Content-Length";
   public static final String HEADER_CONTENT_TYPE = "Content-Type";
+  public static final String HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
   public static final String HEADER_ORIGIN = "Origin";
   public static final String HEADER_REFERER = "Referer";
   public static final String HEADER_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
   public static final String HEADER_OPTIONS = "options";
   public static final String BEARER = "Bearer";
+  public static final String X_CONTENT_TYPE_OPTIONS_NOSNIFF = "nosniff";
 
   /* Implementation specific headers */
   public static final String HEADER_PROVIDER_ID = "providerId";


### PR DESCRIPTION
- As RS servers are performing token API calls during CI/CD now, the ZAP scan throws [an error](https://jenkins.iudx.io/job/iudx%20RS%20%28master%29%20pipeline/61/zap/) complaining about absence of this header
- This error also shows up in the auth ZAP scan, but was [ignored](https://github.com/datakaveri/iudx-aaa-server/pull/142#issuecomment-1076224636) and added to the error threshold
- Adding this header now to avoid changing ZAP error thresholds for RS servers