### PR TITLE
Allow trustees to search for consumers with GET /auth/v1/user/profile

### DIFF
--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -82,7 +82,9 @@ public class Constants {
   public static final String ERR_TITLE_SEARCH_USR_INVALID_ROLE =
       "User does not have required role to search for user";
   public static final String ERR_DETAIL_SEARCH_USR_INVALID_ROLE =
-      "Must have provider/admin roles or be an auth delegate";
+      "Must have provider/trustee/admin roles or be an auth delegate";
+  public static final String ERR_DETAIL_SEARCH_USR_TRUSTEE_ONLY_CONSUMER =
+      "Trustees may only search for consumers";
   
   public static final String ERR_TITLE_INVALID_CLI_ID = "Invalid client ID";
   public static final String ERR_DETAIL_INVALID_CLI_ID = "Requested client ID not found";


### PR DESCRIPTION
- Trustees may want to add registered IUDX users to their APDs and assign them to user classes beforehand
    - this is how it's assumed to be on the RBAC APD
- Currently, the only way to determine if a given email address is a registered IUDX is by using the search endpoint (GET /auth/v1/user/profile)
- Trustees were not allowed to use this API previously, this commit changes that
- The commit also restricts trustees to only search for consumers
--------------
- Unsure if giving trustees this privilege is a good idea
    - since there isn't any restriction to becoming a trustee other than the domain check
- One possible restriction is to check if the trustee has:
    - a registerered APD (can be in any state)
    - an APD in active state (this may be difficult for the trustee, since they would have to wait till their APD state is updated by the admin to add users)