### PR TITLE
Fix auditing service tests and query JSON result formation

### DIFF
--- a/src/main/java/iudx/aaa/server/auditing/AuditingServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/auditing/AuditingServiceImpl.java
@@ -1,21 +1,21 @@
 package iudx.aaa.server.auditing;
 
 import static iudx.aaa.server.auditing.util.Constants.BODY;
-import static iudx.aaa.server.auditing.util.Constants.BODY_COLUMN_NAME;
+import static iudx.aaa.server.auditing.util.Constants.BODY_COLUMN_INDEX;
 import static iudx.aaa.server.auditing.util.Constants.EMPTY_RESPONSE;
 import static iudx.aaa.server.auditing.util.Constants.ENDPOINT;
-import static iudx.aaa.server.auditing.util.Constants.ENDPOINT_COLUMN_NAME;
+import static iudx.aaa.server.auditing.util.Constants.ENDPOINT_COLUMN_INDEX;
 import static iudx.aaa.server.auditing.util.Constants.ERROR;
 import static iudx.aaa.server.auditing.util.Constants.FAILED;
 import static iudx.aaa.server.auditing.util.Constants.MESSAGE;
 import static iudx.aaa.server.auditing.util.Constants.METHOD;
-import static iudx.aaa.server.auditing.util.Constants.METHOD_COLUMN_NAME;
+import static iudx.aaa.server.auditing.util.Constants.METHOD_COLUMN_INDEX;
 import static iudx.aaa.server.auditing.util.Constants.QUERY_KEY;
 import static iudx.aaa.server.auditing.util.Constants.RESULTS;
 import static iudx.aaa.server.auditing.util.Constants.SUCCESS;
 import static iudx.aaa.server.auditing.util.Constants.TIME;
-import static iudx.aaa.server.auditing.util.Constants.TIME_COLUMN_NAME;
-import static iudx.aaa.server.auditing.util.Constants.USERID_COLUMN_NAME;
+import static iudx.aaa.server.auditing.util.Constants.TIME_COLUMN_INDEX;
+import static iudx.aaa.server.auditing.util.Constants.USERID_COLUMN_INDEX;
 import static iudx.aaa.server.auditing.util.Constants.USERID_NOT_FOUND;
 import static iudx.aaa.server.auditing.util.Constants.USER_ID;
 
@@ -204,17 +204,17 @@ public class AuditingServiceImpl implements AuditingService {
 
   private JsonObject getJsonObject(Row rs) {
     JsonObject entries = new JsonObject();
-    LOGGER.debug("COUNT: " + (rs.getString(METHOD_COLUMN_NAME)));
-    LOGGER.debug("TIME: " + (rs.getLong(TIME_COLUMN_NAME)));
-    LOGGER.debug("USERID: " + (rs.getString(USERID_COLUMN_NAME)));
-    LOGGER.debug("BODY: " + (rs.getString(BODY_COLUMN_NAME).replaceAll("\"", " ")));
-    LOGGER.debug("ENDPOINT: " + (rs.getString(ENDPOINT_COLUMN_NAME)));
+    LOGGER.debug("COUNT: " + (rs.getString(METHOD_COLUMN_INDEX)));
+    LOGGER.debug("TIME: " + (rs.getLong(TIME_COLUMN_INDEX)));
+    LOGGER.debug("USERID: " + (rs.getString(USERID_COLUMN_INDEX)));
+    LOGGER.debug("BODY: " + (rs.getString(BODY_COLUMN_INDEX).replaceAll("\"", " ")));
+    LOGGER.debug("ENDPOINT: " + (rs.getString(ENDPOINT_COLUMN_INDEX)));
 
-    entries.put(METHOD, rs.getString(METHOD_COLUMN_NAME));
-    entries.put(TIME, new Timestamp(rs.getLong(TIME_COLUMN_NAME)).toLocalDateTime().toString());
-    entries.put(USER_ID, rs.getString(USERID_COLUMN_NAME));
-    entries.put(BODY, rs.getString(BODY_COLUMN_NAME).replaceAll("\"", " "));
-    entries.put(ENDPOINT, rs.getString(ENDPOINT_COLUMN_NAME));
+    entries.put(METHOD, rs.getString(METHOD_COLUMN_INDEX));
+    entries.put(TIME, new Timestamp(rs.getLong(TIME_COLUMN_INDEX)).toLocalDateTime().toString());
+    entries.put(USER_ID, rs.getString(USERID_COLUMN_INDEX));
+    entries.put(BODY, rs.getString(BODY_COLUMN_INDEX).replaceAll("\"", " "));
+    entries.put(ENDPOINT, rs.getString(ENDPOINT_COLUMN_INDEX));
     return entries;
   }
 }

--- a/src/main/java/iudx/aaa/server/auditing/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/auditing/util/Constants.java
@@ -26,11 +26,6 @@ public class Constants {
   public static final String MISSING_START_TIME = "Start-Time not found.";
   public static final String MISSING_END_TIME = "End-Time not found.";
   public static final String INVALID_TIME = "End-Time cannot be before Start-Time.";
-  public static final String METHOD_COLUMN_NAME = "(defaultdb.table_auditing.method)";
-  public static final String TIME_COLUMN_NAME = "(defaultdb.table_auditing.time)";
-  public static final String USERID_COLUMN_NAME = "(defaultdb.table_auditing.userid)";
-  public static final String BODY_COLUMN_NAME = "(defaultdb.table_auditing.body)";
-  public static final String ENDPOINT_COLUMN_NAME = "(defaultdb.table_auditing.endpoint)";
 
   /* Auditing Service Constants*/
 
@@ -48,4 +43,11 @@ public class Constants {
   public static final String END_TIME_QUERY = " and time<=$3";
   public static final String ENDPOINT_QUERY = " and endpoint='$4'";
   public static final String METHOD_QUERY = " and method='$5'";
+
+  /* Column indices depend on order of columns in READ_QUERY */
+  public static final int BODY_COLUMN_INDEX = 0;
+  public static final int ENDPOINT_COLUMN_INDEX = 1;
+  public static final int METHOD_COLUMN_INDEX = 2;
+  public static final int TIME_COLUMN_INDEX = 3;
+  public static final int USERID_COLUMN_INDEX = 4;
 }


### PR DESCRIPTION
AuditingServiceTest
-------------------
- For `readData` test, add some data beforehand always so that at least
one entry is there before running tests (alternative is to use ordered
tests so that `writeData` etst always runs before `readData`)
- Use current timestamp for `readData` endTime query parameter instead of hardcoded
time. Since we add data beforehand, the query should always work

AuditingServiceImpl
-------------------
- `getJsonObject` function used Row.getString('column name') to get value in column
- But the column name in the result looked like
  `database name + table name + column name`
- Since `database name` can differ, use the column indices i.e. the order of column
names in the query to fetch the data