### PR TITLE
Multiple admins update

### DIFF
--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -150,7 +150,7 @@ public class Constants {
   public static final String GET_URL =
       "SELECT EXISTS (SELECT 1 FROM resource_server WHERE url = $1)";
   
-  public static final String GET_RS = "SELECT resource_server.id FROM resource_server JOIN resource_server_admins" +
+  public static final String GET_RS = "SELECT resource_server.id FROM resource_server LEFT JOIN resource_server_admins" +
           " ON resource_server.id = resource_server_admins.resource_server_id" +
           " WHERE url = $1::text" +
           " AND (resource_server.owner_id = $2::uuid OR resource_server_admins.admin_id = $2::uuid)" +

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -150,6 +150,11 @@ public class Constants {
   public static final String GET_URL =
       "SELECT EXISTS (SELECT 1 FROM resource_server WHERE url = $1)";
   
-  public static final String GET_RS = "SELECT owner_id AS owner FROM resource_server WHERE url = $1";
+  public static final String GET_RS = "SELECT resource_server.id FROM resource_server JOIN resource_server_admins" +
+          " ON resource_server.resource_server_id = resource_server_admins.resource_server_id" +
+          " WHERE url = $1::text" +
+          " AND (resource_server.owner_id = $2::uuid OR resource_server_admins.admin_id = $2::uuid)" +
+          " LIMIT 1";
+
   public static final String GET_APD = "SELECT owner_id AS owner FROM apds WHERE url = $1";
 }

--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -151,7 +151,7 @@ public class Constants {
       "SELECT EXISTS (SELECT 1 FROM resource_server WHERE url = $1)";
   
   public static final String GET_RS = "SELECT resource_server.id FROM resource_server JOIN resource_server_admins" +
-          " ON resource_server.resource_server_id = resource_server_admins.resource_server_id" +
+          " ON resource_server.id = resource_server_admins.resource_server_id" +
           " WHERE url = $1::text" +
           " AND (resource_server.owner_id = $2::uuid OR resource_server_admins.admin_id = $2::uuid)" +
           " LIMIT 1";

--- a/src/main/resources/db/migration/V6__Add_Resource_server_Admins_Table.sql
+++ b/src/main/resources/db/migration/V6__Add_Resource_server_Admins_Table.sql
@@ -12,12 +12,12 @@ ALTER TABLE ONLY resource_server_admins
     ADD CONSTRAINT resource_server_admins_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY resource_server_admins
-    ADD CONSTRAINT r_s_admins_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);
+    ADD CONSTRAINT r_s_admins_owner_id_fkey FOREIGN KEY (admin_id) REFERENCES users(id);
 
 ALTER TABLE ONLY resource_server_admins
     ADD CONSTRAINT r_s_admins_resource_server_id_fkey FOREIGN KEY (resource_server_id) REFERENCES resource_server(id);
 
 ALTER TABLE ONLY resource_server_admins
-    ADD CONSTRAINT unique_server_to_admin UNIQUE (owner_id, resource_server_id);
+    ADD CONSTRAINT unique_server_to_admin UNIQUE (admin_id, resource_server_id);
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE resource_server_admins TO ${authUser};

--- a/src/main/resources/db/migration/V6__Add_Resource_server_Admins_Table.sql
+++ b/src/main/resources/db/migration/V6__Add_Resource_server_Admins_Table.sql
@@ -1,0 +1,23 @@
+CREATE TABLE resource_server_admins (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    admin_id uuid NOT NULL,
+    resource_server_id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+ALTER TABLE resource_server_admins OWNER TO ${flyway:user};
+
+ALTER TABLE ONLY resource_server_admins
+    ADD CONSTRAINT resource_server_admins_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY resource_server_admins
+    ADD CONSTRAINT r_s_admins_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);
+
+ALTER TABLE ONLY resource_server_admins
+    ADD CONSTRAINT r_s_admins_resource_server_id_fkey FOREIGN KEY (resource_server_id) REFERENCES resource_server(id);
+
+ALTER TABLE ONLY resource_server_admins
+    ADD CONSTRAINT unique_server_to_admin UNIQUE (owner_id, resource_server_id);
+
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE resource_server_admins TO ${authUser};


### PR DESCRIPTION
Modified SQL logic to enable multiple-admins flow
* Modified the SQL query in Token Service to obtain the ids of the resource_server belonging to the user present in the request by joining resource_server and resource_server_admins table.
* This enables multiple admins to receive an Identity token if the resource_server is managed by more than one owner/admins.
* This flow only applies to receiving Identity tokens.
* Added new table, resource_server_admins table for enabling multiple admins token flow.