### PR TITLE
Update APD POST /verify JSON request body

### DIFF
--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -111,8 +111,8 @@ public class Constants {
   
   /* APD JSON request keys */
   public static final String APD_REQ_USER = "user";
-  public static final String APD_REQ_PROVIDER = "provider";
-  public static final String APD_REQ_RESOURCE =  "resource";
+  public static final String APD_REQ_OWNER = "owner";
+  public static final String APD_REQ_ITEM =  "item";
   public static final String APD_REQ_USERCLASS = "userClass";
   
   /* APD JSON response keys */

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -49,10 +49,11 @@ public class Constants {
 
   public static final String CALL_APD_APDID = "apdId";
   public static final String CALL_APD_USERID = "userId";
-  public static final String CALL_APD_RESOURCE = "resource";
+  public static final String CALL_APD_ITEM_ID = "itemId";
+  public static final String CALL_APD_ITEM_TYPE = "itemType";
   public static final String CALL_APD_RES_SER_URL = "resSerUrl";
   public static final String CALL_APD_USERCLASS = "userClass";
-  public static final String CALL_APD_PROVIDERID = "providerId";
+  public static final String CALL_APD_OWNERID = "ownerId";
   public static final String CALL_APD_CONSTRAINTS = "constraints";
 
   public static final String RESULTS = "results";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -927,10 +927,11 @@ public class PolicyServiceImpl implements PolicyService {
             JsonObject apdContext = new JsonObject();
 
             apdContext.put(CALL_APD_APDID, apdDetails.getString(APD_ID))
-                .put(CALL_APD_USERID, userId.toString()).put(CALL_APD_RESOURCE, itemId)
+                .put(CALL_APD_USERID, userId.toString()).put(CALL_APD_ITEM_ID, itemId)
+                .put(CALL_APD_ITEM_TYPE, itemType)
                 .put(CALL_APD_RES_SER_URL, getUrl.result())
                 .put(CALL_APD_USERCLASS, apdDetails.getString(USER_CLASS))
-                .put(CALL_APD_PROVIDERID, resDetails.get(itemId).getOwnerId().toString())
+                .put(CALL_APD_OWNERID, resDetails.get(itemId).getOwnerId().toString())
                 .put(CALL_APD_CONSTRAINTS, apdDetails.getJsonObject(CONSTRAINTS));
 
             apdService.callApd(apdContext, p);

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -926,9 +926,13 @@ public class PolicyServiceImpl implements PolicyService {
             JsonObject apdDetails = getApdPolicyDetails.result();
             JsonObject apdContext = new JsonObject();
 
+            /*
+             * itemType is in uppercase when it comes from the CatalogueClient, making it lowercase
+             * explicitly since in the token request, policy listing it's lowercase
+             */
             apdContext.put(CALL_APD_APDID, apdDetails.getString(APD_ID))
                 .put(CALL_APD_USERID, userId.toString()).put(CALL_APD_ITEM_ID, itemId)
-                .put(CALL_APD_ITEM_TYPE, itemType)
+                .put(CALL_APD_ITEM_TYPE, itemType.toLowerCase())
                 .put(CALL_APD_RES_SER_URL, getUrl.result())
                 .put(CALL_APD_USERCLASS, apdDetails.getString(USER_CLASS))
                 .put(CALL_APD_OWNERID, resDetails.get(itemId).getOwnerId().toString())

--- a/src/test/java/iudx/aaa/server/apd/ApdWebClientTest.java
+++ b/src/test/java/iudx/aaa/server/apd/ApdWebClientTest.java
@@ -1,8 +1,8 @@
 package iudx.aaa.server.apd;
 
 import static iudx.aaa.server.apd.Constants.APD_CONSTRAINTS;
-import static iudx.aaa.server.apd.Constants.APD_REQ_PROVIDER;
-import static iudx.aaa.server.apd.Constants.APD_REQ_RESOURCE;
+import static iudx.aaa.server.apd.Constants.APD_REQ_OWNER;
+import static iudx.aaa.server.apd.Constants.APD_REQ_ITEM;
 import static iudx.aaa.server.apd.Constants.APD_REQ_USER;
 import static iudx.aaa.server.apd.Constants.APD_REQ_USERCLASS;
 import static iudx.aaa.server.apd.Constants.APD_RESP_DETAIL;
@@ -97,12 +97,11 @@ public class ApdWebClientTest {
   @DisplayName("Test post verify error cases")
   void testPostVerifyErrors(VertxTestContext testContext) {
     /*
-     * We just put empty objects for user and provider and dummy placeholders for the auth token and
-     * resource ID
+     * We just put empty objects for user, owner and item and dummy placeholders for the auth token
      */
     JsonObject request =
-        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_PROVIDER, new JsonObject())
-            .put(APD_REQ_RESOURCE, "resource").put(APD_REQ_USERCLASS, "TestError");
+        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_OWNER, new JsonObject())
+            .put(APD_REQ_ITEM, new JsonObject()).put(APD_REQ_USERCLASS, "TestError");
     testContext.assertFailure(apdWebClient.callVerifyApdEndpoint("localhost", "token", request))
         .recover(r -> {
           assertTrue(r instanceof ComposeException);
@@ -116,8 +115,8 @@ public class ApdWebClientTest {
   @DisplayName("Test post verify allow")
   void testPostVerifyAllow(VertxTestContext testContext) {
     JsonObject request =
-        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_PROVIDER, new JsonObject())
-            .put(APD_REQ_RESOURCE, "resource").put(APD_REQ_USERCLASS, "TestAllow");
+        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_OWNER, new JsonObject())
+            .put(APD_REQ_ITEM, new JsonObject()).put(APD_REQ_USERCLASS, "TestAllow");
     testContext.assertComplete(apdWebClient.callVerifyApdEndpoint("localhost", "token", request))
         .compose(r -> {
           assertEquals(r.getString(APD_RESP_TYPE), APD_URN_ALLOW);
@@ -131,8 +130,8 @@ public class ApdWebClientTest {
   @DisplayName("Test post verify allow with constraints")
   void testPostVerifyAllowWCons(VertxTestContext testContext) {
       JsonObject request =
-          new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_PROVIDER, new JsonObject())
-              .put(APD_REQ_RESOURCE, "resource").put(APD_REQ_USERCLASS, "TestSuccessWConstraints");
+          new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_OWNER, new JsonObject())
+              .put(APD_REQ_ITEM, new JsonObject()).put(APD_REQ_USERCLASS, "TestSuccessWConstraints");
       testContext.assertComplete(apdWebClient.callVerifyApdEndpoint("localhost", "token", request))
           .compose(r -> {
               assertEquals(r.getString(APD_RESP_TYPE), APD_URN_ALLOW);
@@ -146,8 +145,8 @@ public class ApdWebClientTest {
   @DisplayName("Test post verify deny")
   void testPostVerifyDeny(VertxTestContext testContext) {
     JsonObject request =
-        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_PROVIDER, new JsonObject())
-            .put(APD_REQ_RESOURCE, "resource").put(APD_REQ_USERCLASS, "TestDeny");
+        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_OWNER, new JsonObject())
+            .put(APD_REQ_ITEM, new JsonObject()).put(APD_REQ_USERCLASS, "TestDeny");
     testContext.assertComplete(apdWebClient.callVerifyApdEndpoint("localhost", "token", request))
         .compose(r -> {
           assertEquals(r.getString(APD_RESP_TYPE), APD_URN_DENY);
@@ -162,8 +161,8 @@ public class ApdWebClientTest {
   @DisplayName("Test post verify deny-needs-interaction")
   void testPostVerifyDenyNeedsInteraction(VertxTestContext testContext) {
     JsonObject request =
-        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_PROVIDER, new JsonObject())
-            .put(APD_REQ_RESOURCE, "resource").put(APD_REQ_USERCLASS, "TestDenyNInteraction");
+        new JsonObject().put(APD_REQ_USER, new JsonObject()).put(APD_REQ_OWNER, new JsonObject())
+            .put(APD_REQ_ITEM, new JsonObject()).put(APD_REQ_USERCLASS, "TestDenyNInteraction");
     testContext.assertComplete(apdWebClient.callVerifyApdEndpoint("localhost", "token", request))
         .compose(r -> {
           assertEquals(r.getString(APD_RESP_TYPE), APD_URN_DENY_NEEDS_INT);

--- a/src/test/java/iudx/aaa/server/apd/CallApdTest.java
+++ b/src/test/java/iudx/aaa/server/apd/CallApdTest.java
@@ -181,11 +181,12 @@ public class CallApdTest {
   void apdIdNotExist(VertxTestContext testContext) {
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", UUID.randomUUID().toString())
-        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("ownerId", ownerId.toString()).put("apdId", UUID.randomUUID().toString())
+        .put("itemId", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("itemType", RandomStringUtils.randomAlphabetic(10).toLowerCase())
         .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
         .put("constraints", new JsonObject())
         .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
@@ -206,11 +207,12 @@ public class CallApdTest {
     }).when(registrationService).getUserDetails(any(), any());
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("itemId", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("itemType", RandomStringUtils.randomAlphabetic(10).toLowerCase())
         .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
         .put("constraints", new JsonObject())
         .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
@@ -232,11 +234,12 @@ public class CallApdTest {
     }).when(tokenService).getAuthServerToken(any(), any());
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("itemId", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("itemType", RandomStringUtils.randomAlphabetic(10).toLowerCase())
         .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
         .put("constraints", new JsonObject())
         .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
@@ -274,11 +277,12 @@ public class CallApdTest {
         .thenReturn(Future.failedFuture(new ComposeException(failureResponse)));
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", PENDING_APD_ID.toString())
+        .put("ownerId", ownerId.toString()).put("apdId", PENDING_APD_ID.toString())
         .put("resource", RandomStringUtils.randomAlphabetic(20).toLowerCase())
+        .put("itemType", RandomStringUtils.randomAlphabetic(10).toLowerCase())
         .put("resSerUrl", RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com")
         .put("constraints", new JsonObject())
         .put("userClass", RandomStringUtils.randomAlphabetic(5).toLowerCase());
@@ -320,19 +324,21 @@ public class CallApdTest {
         .thenReturn(Future.succeededFuture(webClientResp));
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
-    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    UUID ownerId = UUID.randomUUID();
+    String itemId = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String itemType = RandomStringUtils.randomAlphabetic(10).toLowerCase();
     String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
     String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("itemId", itemId)
+        .put("itemType", itemType).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
         .put("userClass", userClass);
 
     apdService.callApd(apdContext, testContext.succeeding(response -> testContext.verify(() -> {
       assertEquals(response.getString(CREATE_TOKEN_STATUS), CREATE_TOKEN_SUCCESS);
-      assertEquals(response.getString(CREATE_TOKEN_CAT_ID), resource);
+      assertEquals(response.getString(CREATE_TOKEN_CAT_ID), itemId);
       assertEquals(response.getString(CREATE_TOKEN_URL), resSerUrl);
       assertEquals(response.getJsonObject(CREATE_TOKEN_CONSTRAINTS), new JsonObject());
       testContext.completeNow();
@@ -368,19 +374,21 @@ public class CallApdTest {
         .thenReturn(Future.succeededFuture(webClientResp));
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
-    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    UUID ownerId = UUID.randomUUID();
+    String itemId = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String itemType = RandomStringUtils.randomAlphabetic(10).toLowerCase();
     String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
     String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString()).put("itemType", itemType)
+        .put("itemId", itemId)
+        .put("itemType", itemType).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
         .put("userClass", userClass);
 
     apdService.callApd(apdContext, testContext.succeeding(response -> testContext.verify(() -> {
       assertEquals(response.getString(CREATE_TOKEN_STATUS), CREATE_TOKEN_SUCCESS);
-      assertEquals(response.getString(CREATE_TOKEN_CAT_ID), resource);
+      assertEquals(response.getString(CREATE_TOKEN_CAT_ID), itemId);
       assertEquals(response.getString(CREATE_TOKEN_URL), resSerUrl);
       assertEquals(response.getJsonObject(CREATE_TOKEN_CONSTRAINTS), new JsonObject());
       assertEquals(response.getJsonObject(CREATE_TOKEN_APD_CONSTRAINTS),new JsonObject());
@@ -416,14 +424,16 @@ public class CallApdTest {
         .thenReturn(Future.succeededFuture(webClientResp));
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
-    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    UUID ownerId = UUID.randomUUID();
+    String itemId = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String itemType = RandomStringUtils.randomAlphabetic(10).toLowerCase();
     String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
     String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("itemId", itemId)
+        .put("itemType", itemType).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
         .put("userClass", userClass);
 
     apdService.callApd(apdContext, testContext.failing(response -> testContext.verify(() -> {
@@ -466,14 +476,16 @@ public class CallApdTest {
         .thenReturn(Future.succeededFuture(webClientResp));
 
     UUID userId = UUID.randomUUID();
-    UUID providerId = UUID.randomUUID();
-    String resource = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    UUID ownerId = UUID.randomUUID();
+    String itemId = RandomStringUtils.randomAlphabetic(20).toLowerCase();
+    String itemType = RandomStringUtils.randomAlphabetic(10).toLowerCase();
     String resSerUrl = RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".com";
     String userClass = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
     JsonObject apdContext = new JsonObject().put("userId", userId.toString())
-        .put("providerId", providerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
-        .put("resource", resource).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
+        .put("ownerId", ownerId.toString()).put("apdId", ACTIVE_APD_ID.toString())
+        .put("itemId", itemId)
+        .put("itemType", itemType).put("resSerUrl", resSerUrl).put("constraints", new JsonObject())
         .put("userClass", userClass);
 
     apdService.callApd(apdContext, testContext.succeeding(response -> testContext.verify(() -> {


### PR DESCRIPTION
- `provider` changed to `owner`
- instead of the `resource` key, an `item` JSON object is used, containing
strings `itemId` and `itemType`

- Update verifyPolicy to send item type in the apdContext object
- Change applicable constant names to say `owner` instead of `provider`
-------------
- Updated call APD and APD web client tests due to the request body change