### PR TITLE
Fix existing notification bug

### DIFF
--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -1702,12 +1702,8 @@ public class PolicyServiceImpl implements PolicyService {
                                   .build();
                               handler.handle(Future.succeededFuture(res.toJson()));
                             }).onFailure(fail -> {
-
                               LOGGER.error(LOG_DB_ERROR + fail.getLocalizedMessage());
-                              Response resp =
-                                  new ResponseBuilder().status(400).type(URN_INVALID_INPUT)
-                                      .title(INTERNALERROR).detail(INTERNALERROR).build();
-                              handler.handle(Future.succeededFuture(resp.toJson()));
+                              handler.handle(Future.failedFuture("Internal error"));
                               return;
                             });
                       }

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -1663,9 +1663,8 @@ public class PolicyServiceImpl implements PolicyService {
                                   registrationService.getUserDetails(ids, userHandler -> {
                                     
                                     if (userHandler.failed()) {
-                                      LOGGER.error(
+                                      response.fail(
                                           "Fail: Registration failure; " + userHandler.cause());
-                                      handler.handle(Future.failedFuture(INTERNALERROR));
                                     }
 
                                     if (userHandler.succeeded()) {

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
@@ -603,4 +603,109 @@ public class CreatePolicyNotificationTest {
                     testContext.completeNow();
                 })));
     }
+
+  @Test
+  @DisplayName("Testing failure of registration service and create transaction rollback")
+  void regServiceFailAndRollback(VertxTestContext testContext) {
+
+    /*
+     * The creation of the notification in DB should be rolled back after registration service
+     * failed. So we should be able to:
+     * 
+     * - create a notif request, fail registration service and assert a failed future in response
+     * 
+     * - create the same notification again with successful registration service and get a 200
+     * instead of a 409 in response
+     */
+    String resourceGroup = url + "/da39a3ee5e6b4b0d3255bfef95601890afd80709/" + "rs." + url + "/"
+        + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+    Map<String, List<String>> catClientRequest = new HashMap<String, List<String>>();
+    catClientRequest.put(RES_GRP, List.of(resourceGroup));
+
+    JsonObject ownerJson = provider.result();
+    JsonObject consumerJson = consumer.result();
+
+    UUID consumerId = UUID.fromString(consumerJson.getString("userId"));
+    UUID ownerId = UUID.fromString(ownerJson.getString("userId"));
+    UUID itemIdInDb = UUID.randomUUID();
+    UUID resServerId = UUID.randomUUID();
+
+    /* Mocking CatalogueClient.checkReqItems */
+    Mockito.doAnswer(i -> {
+      Map<String, List<String>> req = i.getArgument(0);
+      String catId = req.get(RES_GRP).get(0);
+      ResourceObj obj = new ResourceObj(RES_GRP, itemIdInDb, catId, ownerId, resServerId, null);
+
+      Map<String, ResourceObj> resp = new HashMap<String, ResourceObj>();
+      resp.put(catId, obj);
+      return Future.succeededFuture(resp);
+    }).when(catalogueClient).checkReqItems(catClientRequest);
+
+    /* mock registrationService to fail */
+    mockRegistrationFactory.setResponse("invalid");
+
+    User user = new UserBuilder().keycloakId(consumerJson.getString("keycloakId"))
+        .userId(consumerJson.getString("userId"))
+        .name(consumerJson.getString("firstName"), consumerJson.getString("lastName"))
+        .roles(List.of(Roles.CONSUMER)).build();
+
+    JsonArray req = new JsonArray()
+        .add(new JsonObject().put("itemId", resourceGroup).put("itemType", "resource_group")
+            .put("expiryDuration", "P1Y").put("constraints", new JsonObject()));
+
+    List<CreatePolicyNotification> request = CreatePolicyNotification.jsonArrayToList(req);
+
+    Checkpoint failed = testContext.checkpoint();
+    Checkpoint success = testContext.checkpoint();
+    policyService.createPolicyNotification(request, user,
+        testContext.failing(fail -> testContext.verify(() -> {
+
+          failed.flag();
+
+          /* Now mocking RegistrationService.getUserDetails to give proper response */
+          JsonObject ownerDetails = new JsonObject().put("email", ownerJson.getString("email"))
+              .put("name", new JsonObject().put("firstName", ownerJson.getString("firstName"))
+                  .put("lastName", ownerJson.getString("lastName")));
+
+          JsonObject consumerDetails =
+              new JsonObject().put("email", consumerJson.getString("email")).put("name",
+                  new JsonObject().put("firstName", consumerJson.getString("firstName"))
+                      .put("lastName", consumerJson.getString("lastName")));
+          JsonObject userDetailsResp = new JsonObject().put(consumerId.toString(), consumerDetails)
+              .put(ownerId.toString(), ownerDetails);
+
+          mockRegistrationFactory.setResponse(userDetailsResp);
+
+          policyService.createPolicyNotification(request, user, testContext.succeeding(response -> {
+            assertEquals(200, response.getInteger("status"));
+            assertEquals(URN_SUCCESS.toString(), response.getString(TYPE));
+            assertEquals(SUCC_TITLE_POLICY_READ, response.getString(TITLE));
+            assertTrue(response.containsKey(RESULTS));
+            assertFalse(response.getJsonArray(RESULTS).isEmpty());
+
+            JsonObject obj = response.getJsonArray(RESULTS).getJsonObject(0);
+
+            assertTrue(obj.containsKey("requestId"));
+
+            // checking user, owner objects. omitted checks for name
+            assertTrue(obj.getJsonObject(OWNER_DETAILS).getString("id")
+                .equals(ownerJson.getString("userId")));
+            assertTrue(obj.getJsonObject(OWNER_DETAILS).getString("email")
+                .equals(ownerJson.getString("email")));
+            assertTrue(obj.getJsonObject(USER_DETAILS).getString("email")
+                .equals(consumerJson.getString("email")));
+            assertTrue(obj.getJsonObject(USER_DETAILS).getString("id")
+                .equals(consumerJson.getString("userId")));
+
+            assertEquals(obj.getString(STATUS), NotifRequestStatus.PENDING.name().toLowerCase());
+            assertEquals(obj.getString("expiryDuration"), request.get(0).getExpiryDuration());
+            assertEquals(obj.getString(ITEMID), resourceGroup);
+            assertEquals(obj.getString(ITEMTYPE), "resource_group");
+            assertTrue(obj.getValue(CONSTRAINTS) instanceof JsonObject);
+            success.flag();
+          }));
+        })));
+  }
+
 }

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
@@ -541,69 +541,6 @@ public class CreatePolicyNotificationTest {
               ));
   }
 
-    @Test
-    @DisplayName("Failing Insertion Handler in DB due to null as constraints")
-    void failedInsertHandler(VertxTestContext testContext) {
-
-        String resourceGroup = url + "/da39a3ee5e6b4b0d3255bfef95601890afd80709/" + "rs." + url + "/"
-                + RandomStringUtils.randomAlphabetic(10).toLowerCase();
-
-        Map<String, List<String>> catClientRequest = new HashMap<String, List<String>>();
-        catClientRequest.put(RES_GRP, List.of(resourceGroup));
-
-        JsonObject ownerJson = provider.result();
-        JsonObject consumerJson = consumer.result();
-
-        UUID consumerId = UUID.fromString(consumerJson.getString("userId"));
-        UUID ownerId = UUID.fromString(ownerJson.getString("userId"));
-        UUID itemIdInDb = UUID.randomUUID();
-        UUID resServerId = UUID.randomUUID();
-
-        /* Mocking CatalogueClient.checkReqItems */
-        Mockito.doAnswer(i -> {
-            Map<String, List<String>> req = i.getArgument(0);
-            String catId = req.get(RES_GRP).get(0);
-            ResourceObj obj = new ResourceObj(RES_GRP, itemIdInDb, catId, ownerId, resServerId, null);
-
-            Map<String, ResourceObj> resp = new HashMap<String, ResourceObj>();
-            resp.put(catId, obj);
-            return Future.succeededFuture(resp);
-        }).when(catalogueClient).checkReqItems(catClientRequest);
-
-        /* Mocking RegistrationService.getUserDetails */
-        JsonObject ownerDetails = new JsonObject().put("email", ownerJson.getString("email"))
-                .put("name", new JsonObject().put("firstName", ownerJson.getString("firstName"))
-                        .put("lastName", ownerJson.getString("lastName")));
-
-        JsonObject consumerDetails = new JsonObject().put("email", consumerJson.getString("email"))
-                .put("name", new JsonObject().put("firstName", consumerJson.getString("firstName"))
-                        .put("lastName", consumerJson.getString("lastName")));
-        JsonObject userDetailsResp = new JsonObject().put(consumerId.toString(), consumerDetails)
-                .put(ownerId.toString(), ownerDetails);
-
-        mockRegistrationFactory.setResponse(userDetailsResp);
-
-        User user = new UserBuilder().keycloakId(consumerJson.getString("keycloakId"))
-                .userId(consumerJson.getString("userId"))
-                .name(consumerJson.getString("firstName"), consumerJson.getString("lastName"))
-                .roles(List.of(Roles.CONSUMER)).build();
-
-        JsonArray req = new JsonArray()
-                .add(new JsonObject().put("itemId", resourceGroup).put("itemType", "resource_group")
-                        .put("expiryDuration", "P1Y").put("constraints", null));
-
-        List<CreatePolicyNotification> request = CreatePolicyNotification.jsonArrayToList(req);
-
-        policyService.createPolicyNotification(request, user,
-                testContext.succeeding(response -> testContext.verify(() -> {
-                    assertEquals(400, response.getInteger("status"));
-                    assertEquals(URN_INVALID_INPUT.toString(), response.getString(TYPE));
-                    assertEquals(INTERNALERROR, response.getString(TITLE));
-                    assertEquals(INTERNALERROR, response.getString("detail"));
-                    testContext.completeNow();
-                })));
-    }
-
   @Test
   @DisplayName("Testing failure of registration service and create transaction rollback")
   void regServiceFailAndRollback(VertxTestContext testContext) {

--- a/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreatePolicyNotificationTest.java
@@ -554,11 +554,11 @@ public class CreatePolicyNotificationTest {
      * - create the same notification again with successful registration service and get a 200
      * instead of a 409 in response
      */
-    String resourceGroup = url + "/da39a3ee5e6b4b0d3255bfef95601890afd80709/" + "rs." + url + "/"
-        + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    String resource = url + "/da39a3ee5e6b4b0d3255bfef95601890afd80709/" + "rs." + url + "/"
+        + RandomStringUtils.randomAlphabetic(10).toLowerCase() + "/" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
     Map<String, List<String>> catClientRequest = new HashMap<String, List<String>>();
-    catClientRequest.put(RES_GRP, List.of(resourceGroup));
+    catClientRequest.put(RES, List.of(resource));
 
     JsonObject ownerJson = provider.result();
     JsonObject consumerJson = consumer.result();
@@ -567,12 +567,13 @@ public class CreatePolicyNotificationTest {
     UUID ownerId = UUID.fromString(ownerJson.getString("userId"));
     UUID itemIdInDb = UUID.randomUUID();
     UUID resServerId = UUID.randomUUID();
+    UUID resGroupId = UUID.randomUUID();
 
     /* Mocking CatalogueClient.checkReqItems */
     Mockito.doAnswer(i -> {
       Map<String, List<String>> req = i.getArgument(0);
-      String catId = req.get(RES_GRP).get(0);
-      ResourceObj obj = new ResourceObj(RES_GRP, itemIdInDb, catId, ownerId, resServerId, null);
+      String catId = req.get(RES).get(0);
+      ResourceObj obj = new ResourceObj(RES, itemIdInDb, catId, ownerId, resServerId, resGroupId);
 
       Map<String, ResourceObj> resp = new HashMap<String, ResourceObj>();
       resp.put(catId, obj);
@@ -587,8 +588,8 @@ public class CreatePolicyNotificationTest {
         .name(consumerJson.getString("firstName"), consumerJson.getString("lastName"))
         .roles(List.of(Roles.CONSUMER)).build();
 
-    JsonArray req = new JsonArray()
-        .add(new JsonObject().put("itemId", resourceGroup).put("itemType", "resource_group")
+    JsonArray req =
+        new JsonArray().add(new JsonObject().put("itemId", resource).put("itemType", "resource")
             .put("expiryDuration", "P1Y").put("constraints", new JsonObject()));
 
     List<CreatePolicyNotification> request = CreatePolicyNotification.jsonArrayToList(req);
@@ -637,8 +638,8 @@ public class CreatePolicyNotificationTest {
 
             assertEquals(obj.getString(STATUS), NotifRequestStatus.PENDING.name().toLowerCase());
             assertEquals(obj.getString("expiryDuration"), request.get(0).getExpiryDuration());
-            assertEquals(obj.getString(ITEMID), resourceGroup);
-            assertEquals(obj.getString(ITEMTYPE), "resource_group");
+            assertEquals(obj.getString(ITEMID), resource);
+            assertEquals(obj.getString(ITEMTYPE), "resource");
             assertTrue(obj.getValue(CONSTRAINTS) instanceof JsonObject);
             success.flag();
           }));


### PR DESCRIPTION
- The existing notification bug i.e. an existing notification was created and a `200 OK` sent instead of a `409 Already Exists` could have been caused by the way the transaction in `pool.withTransaction` was used
- I _think_ there were times the response was sent before the transaction was committed, which is why local unit tests and occasionally integ tests were able to create duplicate notifications. 
    - First request issued, duplicate check returns 0, notif created in transaction, response sent
    - Second request issued, duplicate check returns 0 again - possibly because transaction of the first request has not committed yet - and notif incorrectly created again
----------
The changes made try to organize the code such that _is the response sent (i.e. `handler.handle` called) only when the function in `pool.withTransaction(function)` succeeds/returns a succeeded future_. The vert.x pg docs also mention that when that function succeeds, the transaction is committed, so we can sort of guarantee that when the client receives the response, the data is persisted.

#### Commits
- c334514d1afa99f0ba18635d24392e4db4c8fbc3 - the main bug fix
- 0606780d41324669bca2b37c99b5992cc730da7c, 0a73edbb97532252992c1944363bba83c04c9ba0 - small changes for failure handling
- 7a32bb950f28d9ea977e526987ea9858b69192ae, ec72662ced459dbf091908bb2081f47f8bbc593b - test case for registration service fail, therefore rollback of the transaction
- f390eaf89bc406c585cd79a192852e79c64180b2 - remove test case for explicit DB insertion error - the onFailure block handles it now