### PR TITLE
Bug-fix: Increase header token size limit to 4000

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -156,7 +156,7 @@ paths:
         - schema:
             type: string
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
             example: Bearer <JWT>
           in: header
           name: Authorization
@@ -590,7 +590,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -824,7 +824,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1115,7 +1115,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1391,7 +1391,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1541,7 +1541,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1675,7 +1675,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1897,7 +1897,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2054,7 +2054,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2397,7 +2397,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2482,7 +2482,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2635,7 +2635,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3065,7 +3065,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3202,7 +3202,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3304,7 +3304,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3463,7 +3463,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true
@@ -3620,7 +3620,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true
@@ -3767,7 +3767,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true


### PR DESCRIPTION
- Increase due to large no. of redirect URIs added to Keycloak UI client