### PR TITLE
Bug-fix: Increase header token size limit to 4000

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -156,7 +156,7 @@ paths:
         - schema:
             type: string
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
             example: Bearer <JWT>
           in: header
           name: Authorization
@@ -557,7 +557,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -791,7 +791,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1082,7 +1082,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1358,7 +1358,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1508,7 +1508,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1642,7 +1642,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -1864,7 +1864,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2021,7 +2021,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2364,7 +2364,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2449,7 +2449,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -2602,7 +2602,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3032,7 +3032,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3169,7 +3169,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3271,7 +3271,7 @@ paths:
       parameters:
         - schema:
             type: string
-            maxLength: 3000
+            maxLength: 4000
             minLength: 1
             example: Bearer <JWT>
           in: header
@@ -3430,7 +3430,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true
@@ -3587,7 +3587,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true
@@ -3734,7 +3734,7 @@ paths:
             type: string
             example: Bearer <JWT>
             minLength: 1
-            maxLength: 3000
+            maxLength: 4000
           in: header
           name: Authorization
           required: true


### PR DESCRIPTION
- Increase due to large no. of redirect URIs added to Keycloak UI client