### PR TITLE
[To 3.5.0] Bug-fix: Change fetch name logic for User object

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/Constants.java
@@ -115,7 +115,8 @@ public class Constants {
           + "\", \"detail\":\"" + ERR_DETAIL_NO_SUCH_API + "\"}";
 
   /* General */
-  public static final String NAME = "name";
+  public static final String KC_GIVEN_NAME = "given_name";
+  public static final String KC_FAMILY_NAME = "family_name";
   public static final String SUB = "sub";
   public static final String ID = "id";
   public static final String ROLES = "roles";

--- a/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/OIDCAuthentication.java
@@ -96,12 +96,9 @@ public class OIDCAuthentication implements AuthenticationHandler {
         String kId = mapper.getString(SUB);
         user.keycloakId(kId);
 
-        String[] name = mapper.getString(NAME, " ").split(" ");
-        if (name.length == 2) {
-          user.name(name[0], name[1]);
-        } else {
-          user.name(String.join(" ", name).strip(), null);
-        }
+        String firstName = mapper.getString(KC_GIVEN_NAME, " ");
+        String lastName = mapper.getString(KC_FAMILY_NAME, " ");
+        user.name(firstName, lastName);
 
         return pgSelectUser(SQL_GET_USER_ROLES, kId);
 


### PR DESCRIPTION
- The first name and last name of the user are fetched from the Keycloak token
- The Keycloak token contains `given_name` which is the first name, `family_name` which is last name and `name` which is `given_name<space>family_name`

- The previous code was taking the `name` field from the token and splitting by space to create the first and last names.
- This was causing issues when either the first or last name had spaces
- The new code takes the `given_name` and `family_name`