### PR TITLE
Allow trustees to search for users if they have an auth admin policy

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1156,6 +1156,8 @@ paths:
         A user with either 
         - `provider` role
         - `admin` role
+        - `trustee` role **with valid Auth admin policy**
+            - An auth admin policy is automatically created when an APD belonging to a trustee is set to _active_ state by the IUDX AAA admin
         - is an **auth delegate** 
         may search for a user by providing the email address and role of said user. If a user exists, then the user ID `userId`, email, name and organization details (if applicable) is returned.
 

--- a/src/main/java/iudx/aaa/server/registration/Constants.java
+++ b/src/main/java/iudx/aaa/server/registration/Constants.java
@@ -84,7 +84,7 @@ public class Constants {
   public static final String ERR_TITLE_SEARCH_USR_INVALID_ROLE =
       "User does not have required role to search for user";
   public static final String ERR_DETAIL_SEARCH_USR_INVALID_ROLE =
-      "Must have provider/admin roles or be an auth delegate";
+      "Must have provider/admin/trustee roles or be an auth delegate";
   
   public static final String ERR_TITLE_INVALID_CLI_ID = "Invalid client ID";
   public static final String ERR_DETAIL_INVALID_CLI_ID = "Requested client ID not found";

--- a/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationServiceImpl.java
@@ -79,6 +79,7 @@ import iudx.aaa.server.apiserver.UpdateProfileRequest;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.apiserver.util.ComposeException;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -114,14 +115,16 @@ public class RegistrationServiceImpl implements RegistrationService {
   private PgPool pool;
   private KcAdmin kc;
   private TokenService tokenService;
+  private PolicyService policyService;
   public static String AUTH_SERVER_URL = "";
   public static List<String> SERVERS_OMITTED_FROM_TOKEN_REVOKE = new ArrayList<String>();
 
   public RegistrationServiceImpl(PgPool pool, KcAdmin kc, TokenService tokenService,
-      JsonObject options) {
+      PolicyService policyService, JsonObject options) {
     this.pool = pool;
     this.kc = kc;
     this.tokenService = tokenService;
+    this.policyService = policyService;
     AUTH_SERVER_URL = options.getString(CONFIG_AUTH_URL);
     SERVERS_OMITTED_FROM_TOKEN_REVOKE = options.getJsonArray(CONFIG_OMITTED_SERVERS).stream()
         .map(x -> (String) x).collect(Collectors.toList());

--- a/src/main/java/iudx/aaa/server/registration/RegistrationVerticle.java
+++ b/src/main/java/iudx/aaa/server/registration/RegistrationVerticle.java
@@ -28,6 +28,7 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.sqlclient.PoolOptions;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 
 /**
@@ -65,12 +66,14 @@ public class RegistrationVerticle extends AbstractVerticle {
   private static JsonObject options;
   private static final String REGISTRATION_SERVICE_ADDRESS = "iudx.aaa.registration.service";
   private static final String TOKEN_SERVICE_ADDRESS = "iudx.aaa.token.service";
+  private static final String POLICY_SERVICE_ADDRESS = "iudx.aaa.policy.service";
   private RegistrationService registrationService;
   private ServiceBinder binder;
   private MessageConsumer<JsonObject> consumer;
   private static final Logger LOGGER = LogManager.getLogger(RegistrationVerticle.class);
   
   private TokenService tokenService;
+  private PolicyService policyService;
 
   /**
    * This method is used to start the Verticle. It deploys a verticle in a cluster, registers the
@@ -124,7 +127,9 @@ public class RegistrationVerticle extends AbstractVerticle {
         keycloakAdminClientSecret, keycloakAdminPoolSize);
 
     tokenService = TokenService.createProxy(vertx, TOKEN_SERVICE_ADDRESS);
-    registrationService = new RegistrationServiceImpl(pool, kcadmin, tokenService, options);
+    policyService = PolicyService.createProxy(vertx, POLICY_SERVICE_ADDRESS);
+    registrationService =
+        new RegistrationServiceImpl(pool, kcadmin, tokenService, policyService, options);
     binder = new ServiceBinder(vertx);
     consumer = binder.setAddress(REGISTRATION_SERVICE_ADDRESS)
         .register(RegistrationService.class, registrationService);

--- a/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
@@ -44,6 +44,7 @@ import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,7 @@ public class CreateUserTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
 
   private static final String UUID_REGEX =
@@ -131,7 +133,8 @@ public class CreateUserTest {
     orgIdFut =
         pool.withConnection(conn -> conn.preparedQuery(SQL_CREATE_ORG).execute(Tuple.of(name, url))
             .map(row -> row.iterator().next().getUUID("id"))).onSuccess(err -> {
-              registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+              registrationService =
+                  new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
               testContext.completeNow();
             }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/GetUserDetailsTest.java
+++ b/src/test/java/iudx/aaa/server/registration/GetUserDetailsTest.java
@@ -24,6 +24,7 @@ import io.vertx.sqlclient.Tuple;
 import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ public class GetUserDetailsTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
 
   static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
@@ -139,7 +141,8 @@ public class GetUserDetailsTest {
     userNoOrg = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesB, false);
 
     CompositeFuture.all(userWithOrg, userNoOrg).onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+      registrationService =
+          new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/ListOrganizationTest.java
+++ b/src/test/java/iudx/aaa/server/registration/ListOrganizationTest.java
@@ -19,6 +19,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Tuple;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,7 @@ public class ListOrganizationTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
 
   static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
@@ -102,7 +104,8 @@ public class ListOrganizationTest {
     orgIdFut =
         pool.withConnection(conn -> conn.preparedQuery(SQL_CREATE_ORG).execute(Tuple.of(name, url))
             .map(row -> row.iterator().next().getUUID("id"))).onSuccess(err -> {
-              registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+              registrationService =
+                  new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
               testContext.completeNow();
             }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/ListUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/ListUserTest.java
@@ -37,6 +37,7 @@ import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.HashMap;
 import java.util.List;
@@ -74,6 +75,7 @@ public class ListUserTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
   
   private static final String UUID_REGEX =
@@ -143,7 +145,8 @@ public class ListUserTest {
     userNoOrg = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesB, false);
 
     CompositeFuture.all(userWithOrg, userNoOrg).onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+      registrationService =
+          new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
@@ -11,6 +11,8 @@ import static iudx.aaa.server.registration.Constants.ERR_TITLE_SEARCH_USR_INVALI
 import static iudx.aaa.server.registration.Constants.ERR_TITLE_USER_NOT_FOUND;
 import static iudx.aaa.server.registration.Constants.RESP_ORG;
 import static iudx.aaa.server.registration.Constants.SUCC_TITLE_USER_FOUND;
+import static iudx.aaa.server.policy.Constants.NO_AUTH_POLICY;
+import static iudx.aaa.server.policy.Constants.NO_AUTH_ADMIN_POLICY;
 import static iudx.aaa.server.registration.Utils.SQL_CREATE_ORG;
 import static iudx.aaa.server.registration.Utils.SQL_DELETE_ORG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +34,7 @@ import iudx.aaa.server.apiserver.RoleStatus;
 import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
+import iudx.aaa.server.apiserver.util.ComposeException;
 import iudx.aaa.server.configuration.Configuration;
 import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
@@ -83,6 +86,7 @@ public class SearchUserTest {
 
   static Future<JsonObject> providerDeleg;
   static Future<JsonObject> consumerAdmin;
+  static Future<JsonObject> trustee;
   static Future<UUID> orgIdFut;
 
   @BeforeAll
@@ -121,7 +125,7 @@ public class SearchUserTest {
     options.put(CONFIG_AUTH_URL, dbConfig.getString(CONFIG_AUTH_URL)).put(CONFIG_OMITTED_SERVERS,
         dbConfig.getJsonArray(CONFIG_OMITTED_SERVERS));
     /*
-     * create fake organization, and create 2 mock users. One user has an organization + phone
+     * create fake organization, and create 3 mock users. One user has an organization + phone
      * number other does not
      */
 
@@ -136,11 +140,15 @@ public class SearchUserTest {
     rolesB.put(Roles.CONSUMER, RoleStatus.APPROVED);
     rolesB.put(Roles.ADMIN, RoleStatus.APPROVED);
 
+    Map<Roles, RoleStatus> rolesC = new HashMap<Roles, RoleStatus>();
+    rolesC.put(Roles.TRUSTEE, RoleStatus.APPROVED);
+
     providerDeleg =
         orgIdFut.compose(id -> Utils.createFakeUser(pool, id.toString(), url, rolesA, true));
     consumerAdmin = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesB, false);
+    trustee = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesC, false);
 
-    CompositeFuture.all(providerDeleg, consumerAdmin).onSuccess(res -> {
+    CompositeFuture.all(providerDeleg, consumerAdmin, trustee).onSuccess(res -> {
       registrationService =
           new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
       testContext.completeNow();
@@ -151,7 +159,9 @@ public class SearchUserTest {
   public static void finish(VertxTestContext testContext) {
     LOGGER.info("Finishing and resetting DB");
 
-    Utils.deleteFakeUser(pool, List.of(consumerAdmin.result(), providerDeleg.result()))
+    Utils
+        .deleteFakeUser(pool,
+            List.of(consumerAdmin.result(), providerDeleg.result(), trustee.result()))
         .compose(success -> pool.withConnection(
             conn -> conn.preparedQuery(SQL_DELETE_ORG).execute(Tuple.of(orgIdFut.result()))))
         .onComplete(x -> {
@@ -454,6 +464,85 @@ public class SearchUserTest {
           assertEquals(ERR_TITLE_USER_NOT_FOUND, response.getString("title"));
           assertEquals(ERR_DETAIL_USER_NOT_FOUND, response.getString("detail"));
           assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("Test search - trustee does not have auth admin policy")
+  void searchTrusteeNoAuthAdminPolicy(VertxTestContext testContext) {
+    JsonObject userJson = trustee.result();
+    List<Roles> roles = List.of(Roles.TRUSTEE);
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId")).roles(roles)
+        .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+    Mockito.doAnswer(i -> {
+      Promise<Void> p = i.getArgument(1);
+      p.fail(new ComposeException(403, URN_INVALID_INPUT, NO_AUTH_POLICY, NO_AUTH_ADMIN_POLICY));
+      return i.getMock();
+    }).when(policyService).checkAuthPolicy(Mockito.eq(userJson.getString("userId")), any());
+
+    JsonObject consumerUser = consumerAdmin.result();
+
+    JsonObject searchUser = new JsonObject().put("email", consumerUser.getString("email"))
+        .put("role", Roles.CONSUMER.toString().toLowerCase());
+    
+    registrationService.listUser(user, searchUser, new JsonObject(),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(403, response.getInteger("status"));
+          assertEquals(NO_AUTH_POLICY, response.getString("title"));
+          assertEquals(NO_AUTH_ADMIN_POLICY, response.getString("detail"));
+          assertEquals(URN_INVALID_INPUT.toString(), response.getString("type"));
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  @DisplayName("Test search - trustee finds consumer successfully")
+  void searchTrusteeFindConsumer(VertxTestContext testContext) {
+    JsonObject userJson = trustee.result();
+    List<Roles> roles = List.of(Roles.TRUSTEE);
+
+    User user = new UserBuilder().keycloakId(userJson.getString("keycloakId"))
+        .userId(userJson.getString("userId")).roles(roles)
+        .name(userJson.getString("firstName"), userJson.getString("lastName")).build();
+
+    JsonObject consumerUser = consumerAdmin.result();
+
+    Mockito.doAnswer(i -> {
+      Promise<Void> p = i.getArgument(1);
+      p.complete();
+      return i.getMock();
+    }).when(policyService).checkAuthPolicy(Mockito.eq(userJson.getString("userId")), any());
+
+    JsonObject kcResult = new JsonObject().put("keycloakId", consumerUser.getString("keycloakId"))
+        .put("email", consumerUser.getString("email"))
+        .put("name", new JsonObject().put("firstName", consumerUser.getString("firstName"))
+            .put("lastName", consumerUser.getString("lastName")));
+
+    Mockito.when(kc.findUserByEmail(consumerUser.getString("email")))
+        .thenReturn(Future.succeededFuture(kcResult));
+
+    JsonObject searchUser = new JsonObject().put("email", consumerUser.getString("email"))
+        .put("role", Roles.CONSUMER.toString().toLowerCase());
+    
+    registrationService.listUser(user, searchUser, new JsonObject(),
+        testContext.succeeding(response -> testContext.verify(() -> {
+          assertEquals(200, response.getInteger("status"));
+          assertEquals(SUCC_TITLE_USER_FOUND, response.getString("title"));
+          assertEquals(URN_SUCCESS.toString(), response.getString("type"));
+
+          JsonObject result = response.getJsonObject("results");
+
+          JsonObject name = result.getJsonObject("name");
+          assertEquals(name.getString("firstName"), consumerUser.getString("firstName"));
+          assertEquals(name.getString("lastName"), consumerUser.getString("lastName"));
+
+          assertTrue(result.getJsonObject(RESP_ORG) == null);
+          assertEquals(result.getString("userId"), consumerUser.getString("userId"));
+
           testContext.completeNow();
         })));
   }

--- a/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/SearchUserTest.java
@@ -33,6 +33,7 @@ import iudx.aaa.server.apiserver.Roles;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +71,7 @@ public class SearchUserTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
   
   private static final String UUID_REGEX =
@@ -139,7 +141,8 @@ public class SearchUserTest {
     consumerAdmin = Utils.createFakeUser(pool, Constants.NIL_UUID, "", rolesB, false);
 
     CompositeFuture.all(providerDeleg, consumerAdmin).onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+      registrationService =
+          new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/UpdateUserTest.java
@@ -55,6 +55,7 @@ import iudx.aaa.server.apiserver.UpdateProfileRequest;
 import iudx.aaa.server.apiserver.User;
 import iudx.aaa.server.apiserver.User.UserBuilder;
 import iudx.aaa.server.configuration.Configuration;
+import iudx.aaa.server.policy.PolicyService;
 import iudx.aaa.server.token.TokenService;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -93,6 +94,7 @@ public class UpdateUserTest {
 
   private static KcAdmin kc = Mockito.mock(KcAdmin.class);
   private static TokenService tokenService = Mockito.mock(TokenService.class);
+  private static PolicyService policyService = Mockito.mock(PolicyService.class);
   private static JsonObject options = new JsonObject();
 
   static String name = RandomStringUtils.randomAlphabetic(10).toLowerCase();
@@ -178,7 +180,8 @@ public class UpdateUserTest {
       return pool.withConnection(
           conn -> conn.preparedQuery(SQL_CREATE_ADMIN_SERVER).executeBatch(servers));
     }).onSuccess(res -> {
-      registrationService = new RegistrationServiceImpl(pool, kc, tokenService, options);
+      registrationService =
+          new RegistrationServiceImpl(pool, kc, tokenService, policyService, options);
       testContext.completeNow();
     }).onFailure(err -> testContext.failNow(err.getMessage()));
   }

--- a/src/test/resources/Integration_Test.postman_collection.json
+++ b/src/test/resources/Integration_Test.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d06fe8a7-02ce-4925-ae76-16438c7b84b2",
+		"_postman_id": "94928842-8d7a-4406-8de8-703163d41d7b",
 		"name": "Integration Test",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "14598828"
 	},
 	"item": [
 		{
@@ -7026,7 +7027,67 @@
 					"response": []
 				},
 				{
-					"name": "Delegate (no delegations set) searching",
+					"name": "Trustee (with no auth admin policy) searching",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
+								"type": "text"
+							},
+							{
+								"key": "email",
+								"value": "consumer@gmail.com",
+								"type": "text"
+							},
+							{
+								"key": "role",
+								"value": "consumer",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delegate searching without providerId header",
 					"event": [
 						{
 							"listen": "test",
@@ -7056,7 +7117,7 @@
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
+								"value": "Bearer {{POSTMAN_DELEGATE_TOKEN}}",
 								"type": "text"
 							},
 							{
@@ -7191,6 +7252,73 @@
 							{
 								"key": "Authorization",
 								"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
+								"type": "text"
+							},
+							{
+								"key": "email",
+								"value": "consumer@gmail.com",
+								"type": "text"
+							},
+							{
+								"key": "role",
+								"value": "consumer",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/user/profile",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"user",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Trustee with auth admin policy searching",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
+									"    pm.expect(body.title).to.be.eq(\"User found\");",
+									"    const result = body.results;",
+									"    pm.expect(result).to.have.property(\"email\", \"consumer@gmail.com\");",
+									"    pm.expect(result).to.have.property(\"userId\", pm.environment.get(\"CONSUMER_GMAIL_USERID\"));",
+									"    pm.expect(result.name).to.not.be.empty;",
+									"    pm.expect(result.organization).to.not.exist;",
+									"    ",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{POSTMAN_TRUSTEE_TOKEN}}",
 								"type": "text"
 							},
 							{


### PR DESCRIPTION
- Added PolicyService dependency to RegistrationService
- Updated Reg service tests for PolicyService dependency
- Added trustee search feature 
- Added tests
- Updated openapi docs