### PR TITLE
Jenkins: v4.0.0 pipeline updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,9 +84,9 @@ pipeline {
         always{
           node('built-in') {
             script{
+              publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/aaa/Newman/report/', reportFiles: 'report.html', reportName: 'HTML Report', reportTitles: '', reportName: 'Integration Test Report'])
               archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 2
             }  
-            publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/aaa/Newman/report/', reportFiles: 'report.html', reportName: 'HTML Report', reportTitles: '', reportName: 'Integration Test Report'])
           }
         }
         failure{

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(master)%20pipeline/lastBuild/)
-[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(master)%20pipeline/lastBuild/jacoco/)
-[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28master%29%2520pipeline%2F&label=unit%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(master)%20pipeline/lastBuild/testReport/)
-[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28master%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(master)%20pipeline/lastBuild/zap/)
-[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28master%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(master)%20pipeline/Integration_20Test_20Report/)
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(v4.0.0)%20pipeline/lastBuild/)
+[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(v4.0.0)%20pipeline/lastBuild/jacoco/)
+[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28v4.0.0%29%2520pipeline%2F&label=unit%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(v4.0.0)%20pipeline/lastBuild/testReport/)
+[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28v4.0.0%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(v4.0.0)%20pipeline/lastBuild/zap/)
+[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520aaa-server%2520%28v4.0.0%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20aaa-server%20(v4.0.0)%20pipeline/Integration_20Test_20Report/)
 
 
 ![IUDX](./readme/images/iudx.png)

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,8 +10,8 @@ services:
       - LOG_LEVEL=INFO
       - AUTH_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/aaa-config-test.json:/usr/share/app/configs/config-test.json
-      - /home/ubuntu/configs/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/4.0.0/aaa-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/4.0.0/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./src/:/usr/share/app/src
       - ${WORKSPACE}:/tmp/test
@@ -20,20 +20,26 @@ services:
       - auth-net
 
   integTest:
-    image: ghcr.io/datakaveri/aaa-test:latest
+    image: ghcr.io/datakaveri/aaa-depl:latest
     environment:
       - AUTH_URL=https://authorization.iudx.org.in
       - LOG_LEVEL=INFO
       - AUTH_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/aaa-config-integ.json:/usr/share/app/configs/config-dev.json
-      - /home/ubuntu/configs/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
-      - /home/ubuntu/configs/aaa-flyway.conf:/usr/share/app/flyway.conf
-      - ./docs/:/usr/share/app/docs
-      - ./src/:/usr/share/app/src
-    command: bash -c "mvn clean compile exec:java@aaa-server"
+      - /home/ubuntu/configs/4.0.0/aaa-config-integ.json:/usr/share/app/configs/config.json
+      - /home/ubuntu/configs/4.0.0/aaa-keystore.jks:/usr/share/app/configs/keystore.jks
+    command: bash -c "exec java $$AUTH_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
     ports:
       - "8080:8080"
       - "8443:8443"
+    networks:
+      - auth-net
+    depends_on:
+      - "zookeeper"
+
+  zookeeper:
+    image: zookeeper:latest
+    expose: 
+      - "2181"
     networks:
       - auth-net


### PR DESCRIPTION
- fix for first issue in #255 : Newman report will now be published to jenkins even if zap tests fail
- fix git badges to point to v4.0.0 pipeline
- updated to use depl image in integ test stage