### PR TITLE
Added `context` object to token API request body

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -208,6 +208,8 @@ paths:
                     - consumer
                     - admin
                     - trustee
+                context:
+                  type: object
               required:
                 - itemId
                 - itemType
@@ -263,11 +265,20 @@ paths:
                   itemId: rs.iudx.org.in
                   itemType: resource_server
                   role: provider
+              Requesting resource with context object in body:
+                value:
+                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm
+                  itemType: resource_group
+                  role: consumer
+                  context:
+                    accessId: 1e5aad64-102c-4688-892f-c6a1f5f4d476
+                    accessType: PERMANENT_ACCESS
         description: |-
           - `itemId` : the string value of the id of the resource
             - e.g. `datakaveri.org/facec5182e3bf44cc3ac42b0b611263676d668a2/rs.iudx.org.in/agartala-env-aqm`
           - `itemType` : the kind of item the desired resource is
           - `role` : the role as which the user wants to get token for
+          - `context` : a JSON object containing any extra information. The user may use this field to convey information to an APD in case the requested resource is backed by an APD policy
         required: true
       description: |
         Request for a JWT (token). One can generate token using either by providing token header or providing clientId and clientSecret in the header. 
@@ -340,6 +351,11 @@ paths:
 
         - **Deny** : The user does not belong to the user class. The AAA server returns a `403 Forbidden`.
         - **Deny but the APD needs interaction** : The user does not belong to the user class, but the APD provides a mechanism for the user to interact with it. This interaction **may or may not** result in the user being included in the user class. The AAA server sends a `403 Forbidden` but includes a special **APD JWT token** that the user must use when interacting with the APD. 
+
+        ## Context object for extra information
+        An APD may require extra information during user class evaluation. Any such information can be included in the `context` JSON object field in the API request body. 
+
+        In case an APD requires particular keys in the `context` object, The APD can send a **Deny** response with the details of the required keys and information.
 
         ## JWT APD Token Response Structure
           The JWT is signed using the ES256 algorithm (`alg:ES256`).

--- a/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/apd/ApdServiceImpl.java
@@ -2,6 +2,7 @@ package iudx.aaa.server.apd;
 
 import static iudx.aaa.server.apd.Constants.APD_CONSTRAINTS;
 import static iudx.aaa.server.apd.Constants.APD_NOT_ACTIVE;
+import static iudx.aaa.server.apd.Constants.APD_REQ_CONTEXT;
 import static iudx.aaa.server.apd.Constants.APD_REQ_ITEM;
 import static iudx.aaa.server.apd.Constants.APD_REQ_OWNER;
 import static iudx.aaa.server.apd.Constants.APD_REQ_USER;
@@ -778,6 +779,7 @@ public class ApdServiceImpl implements ApdService {
     String rsUrl = apdContext.getString("resSerUrl");
     String userClass = apdContext.getString("userClass");
     JsonObject constraints = apdContext.getJsonObject("constraints");
+    JsonObject context = apdContext.getJsonObject("context");
 
     Collector<Row, ?, List<JsonObject>> collector =
         Collectors.mapping(row -> row.toJson(), Collectors.toList());
@@ -814,8 +816,8 @@ public class ApdServiceImpl implements ApdService {
           String token = authAccessToken.result().getString("accessToken");
           String apdUrl = apdDetails.result().get(0).getString("url");
 
-          apdRequest.put(APD_REQ_USER, user).put(APD_REQ_OWNER, owner)
-              .put(APD_REQ_ITEM, item).put(APD_REQ_USERCLASS, userClass);
+          apdRequest.put(APD_REQ_USER, user).put(APD_REQ_OWNER, owner).put(APD_REQ_ITEM, item)
+              .put(APD_REQ_USERCLASS, userClass).put(APD_REQ_CONTEXT, context);
 
           return apdWebClient.callVerifyApdEndpoint(apdUrl, token, apdRequest);
         });

--- a/src/main/java/iudx/aaa/server/apd/Constants.java
+++ b/src/main/java/iudx/aaa/server/apd/Constants.java
@@ -114,6 +114,7 @@ public class Constants {
   public static final String APD_REQ_OWNER = "owner";
   public static final String APD_REQ_ITEM =  "item";
   public static final String APD_REQ_USERCLASS = "userClass";
+  public static final String APD_REQ_CONTEXT = "context";
   
   /* APD JSON response keys */
   public static final String APD_RESP_TYPE = "type";

--- a/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/aaa/server/apiserver/ApiServerVerticle.java
@@ -387,7 +387,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     /* Mapping request body to Object */
     JsonObject tokenRequestJson = context.body().asJsonObject();
     tokenRequestJson.put(CLIENT_ID, context.get(CLIENT_ID));
-    RequestToken requestTokenDTO = tokenRequestJson.mapTo(RequestToken.class);
+    RequestToken requestTokenDTO = new RequestToken(tokenRequestJson);
     User user = context.get(USER);
 
     tokenService.createToken(requestTokenDTO, user, handler -> {

--- a/src/main/java/iudx/aaa/server/apiserver/RequestToken.java
+++ b/src/main/java/iudx/aaa/server/apiserver/RequestToken.java
@@ -29,6 +29,9 @@ public class RequestToken {
   @JsonAlias("itemId")
   private String itemId;
 
+  @JsonAlias("context")
+  private JsonObject context = new JsonObject();
+
   public JsonObject toJson() {
     JsonObject request = new JsonObject();
     RequestTokenConverter.toJson(this, request);
@@ -72,4 +75,13 @@ public class RequestToken {
   public void setItemId(String itemId) {
     this.itemId = itemId;
   }
+
+  public JsonObject getContext() {
+    return context;
+  }
+
+  public void setContext(JsonObject context) {
+    this.context = context;
+  }
+
 }

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
   public static final String ITEMTYPE = "itemType";
   public static final String ROLE = "role";
   public static final String CONSTRAINTS = "constraints";
+  public static final String CONTEXT = "context";
   public static final String EXPIRYTIME = "expiryTime";
   public static final String OWNERID = "ownerId";
   public static final String RESOURCETABLE = "resource";
@@ -55,6 +56,7 @@ public class Constants {
   public static final String CALL_APD_USERCLASS = "userClass";
   public static final String CALL_APD_OWNERID = "ownerId";
   public static final String CALL_APD_CONSTRAINTS = "constraints";
+  public static final String CALL_APD_CONTEXT = "context";
 
   public static final String RESULTS = "results";
   public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";

--- a/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/policy/PolicyServiceImpl.java
@@ -803,7 +803,7 @@ public class PolicyServiceImpl implements PolicyService {
   }
 
   Future<JsonObject> verifyConsumerPolicy(UUID userId, String itemId, String itemType,
-      Map<String, ResourceObj> resDetails) {
+      JsonObject context, Map<String, ResourceObj> resDetails) {
 
     Promise<JsonObject> p = Promise.promise();
 
@@ -934,6 +934,7 @@ public class PolicyServiceImpl implements PolicyService {
                 .put(CALL_APD_RES_SER_URL, getUrl.result())
                 .put(CALL_APD_USERCLASS, apdDetails.getString(USER_CLASS))
                 .put(CALL_APD_OWNERID, resDetails.get(itemId).getOwnerId().toString())
+                .put(CALL_APD_CONTEXT, context)
                 .put(CALL_APD_CONSTRAINTS, apdDetails.getJsonObject(CONSTRAINTS));
 
             apdService.callApd(apdContext, p);
@@ -1318,6 +1319,8 @@ public class PolicyServiceImpl implements PolicyService {
     String itemId = request.getString(ITEMID);
     String itemType = request.getString(ITEMTYPE).toUpperCase();
     String role = request.getString(ROLE).toUpperCase();
+    /* context will be empty JSON object if not set by user; see RequestToken */
+    JsonObject context = request.getJsonObject(CONTEXT);
 
     boolean isCatalogue = false;
     // verify policy does not expect the resServer itemType
@@ -1448,7 +1451,7 @@ public class PolicyServiceImpl implements PolicyService {
                       {
                         response =
                             verifyConsumerPolicy(
-                                userId, finalItem, itemType, reqItemDetail.result());
+                                userId, finalItem, itemType, context, reqItemDetail.result());
                         break;
                       }
                     case PROVIDER_ROLE:

--- a/src/test/resources/Integration_Test.postman_collection.json
+++ b/src/test/resources/Integration_Test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "94928842-8d7a-4406-8de8-703163d41d7b",
+		"_postman_id": "24e9bf0c-7446-4951-bad4-ae2d4ad84424",
 		"name": "Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "14598828"
@@ -8964,6 +8964,62 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\":\"resource_group\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Invalid context - [400]",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{CONSUMER_GMAIL_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\":\"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": \"hello\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27011,6 +27067,68 @@
 								"auth",
 								"v1",
 								"introspect"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Consumer get token for integration-test-rsg-one with context object (APD policy for it)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check response header\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+									"});",
+									"",
+									"pm.test(\"Check response body\", function () {    ",
+									"    const body = pm.response.json();",
+									"    const moment = require('moment');",
+									"",
+									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
+									"    const result = body.results;",
+									"    pm.expect(result).to.have.property(\"accessToken\");",
+									"    pm.expect(result.expiry).to.be.greaterThan(moment().unix());",
+									"    pm.expect(result.server).to.be.eq(\"rs.iudx.io\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{CONSUMER_GMAIL_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": {\n        \"accessType\": \"SOME_ACCESS_TYPE\",\n        \"accessId\": 1234,\n        \"accessList\": [\n            123,\n            \"2\",\n            {\n                \"list\": \"four\"\n            }\n        ],\n        \"accessObject\": {\n            \"access\": \"Y\"\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
+							"host": [
+								"{{AUTH_ENDPOINT}}"
+							],
+							"path": [
+								"auth",
+								"v1",
+								"token"
 							]
 						}
 					},


### PR DESCRIPTION
RequestToken
------------
- Add `context` JsonObject field
- If not added in request, will be empty JSON object by default

PolicyServiceImpl
-----------------
- Get context from token request
- Add context to verifyConsumerPolicy method and when calling APD service

ApdServiceImpl
--------------
- Add context to APD `POST /verify` request body

ApiServerVerticle
-----------------
- When casting JSON request body to RequestToken, use the RequestToken constructor instead of `mapTo`
	- `mapTo` caused issues - the context object can have any keys in it and for some reason mapTo didn't like that

OpenAPI
-------
- Updated token docs and added example

Postman
-------
- Added test for invalid context field
- Added test for passing context object containing all sorts of fields for a valid APD policy-backed token request