### PR TITLE
Added user details in identity token introspection result

### DIFF
--- a/src/main/java/iudx/aaa/server/token/Constants.java
+++ b/src/main/java/iudx/aaa/server/token/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   
   public static final String TOKEN_SERVICE_ADDRESS = "iudx.aaa.token.service";
   public static final String POLICY_SERVICE_ADDRESS = "iudx.aaa.policy.service";
+  public static final String REGISTRATION_SERVICE_ADDRESS = "iudx.aaa.registration.service";
   
   public static final int BCRYPT_SALT_LEN = 16;
   public static final int BCRYPT_LOG_COST = 12;
@@ -86,6 +87,7 @@ public class Constants {
   public static final String IID = "iid";
   public static final String CONS = "cons";
   public static final String APD = "apd";
+  public static final String INTROSPECT_USERINFO = "userInfo";
   
   /* JWT Constants for APD token */
   public static final String LINK = "link";

--- a/src/main/java/iudx/aaa/server/token/TokenVerticle.java
+++ b/src/main/java/iudx/aaa/server/token/TokenVerticle.java
@@ -13,6 +13,7 @@ import io.vertx.pgclient.PgPool;
 import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.sqlclient.PoolOptions;
 import iudx.aaa.server.policy.PolicyService;
+import iudx.aaa.server.registration.RegistrationService;
 import static iudx.aaa.server.token.Constants.*;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ public class TokenVerticle extends AbstractVerticle {
   private TokenService tokenService;  
   private JWTAuth provider;
   private PolicyService policyService;
+  private RegistrationService registrationService;
   private ServiceBinder binder;
   private MessageConsumer<JsonObject> consumer;
   private TokenRevokeService revokeService;
@@ -100,7 +102,9 @@ public class TokenVerticle extends AbstractVerticle {
     revokeService = new TokenRevokeService(vertx);
     pgPool = PgPool.pool(vertx, connectOptions, poolOptions);
     policyService = PolicyService.createProxy(vertx, POLICY_SERVICE_ADDRESS);
-    tokenService = new TokenServiceImpl(pgPool, policyService, provider, revokeService);
+    registrationService = RegistrationService.createProxy(vertx, REGISTRATION_SERVICE_ADDRESS);
+    tokenService =
+        new TokenServiceImpl(pgPool, policyService, registrationService, provider, revokeService);
     binder = new ServiceBinder(vertx);
     consumer = binder.setAddress(TOKEN_SERVICE_ADDRESS).register(TokenService.class,
         tokenService);

--- a/src/test/resources/Integration_Test.postman_collection.json
+++ b/src/test/resources/Integration_Test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "24e9bf0c-7446-4951-bad4-ae2d4ad84424",
+		"_postman_id": "ab5b6ce1-92fa-490f-b259-900e95ef1c55",
 		"name": "Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "14598828"
@@ -7637,6 +7637,11 @@
 											"    pm.expect(result.role).to.be.eq(\"admin\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
+											"",
+											"    pm.expect(result.userInfo).to.exist;",
+											"    const userInfo = result.userInfo;",
+											"    pm.expect(userInfo.email).to.be.eq(\"auth.admin@datakaveri.org\");",
+											"    pm.expect(userInfo).to.have.property(\"name\");    ",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7848,6 +7853,135 @@
 				{
 					"name": "Provider",
 					"item": [
+						{
+							"name": "Provider role get rs.iudx.io token - [200]",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check response header\", function () {",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+											"});",
+											"",
+											"pm.test(\"Check response body\", function () {    ",
+											"    const body = pm.response.json();",
+											"    const moment = require('moment');",
+											"",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
+											"    const result = body.results;",
+											"    pm.expect(result).to.have.property(\"accessToken\");",
+											"    pm.expect(result.expiry).to.be.greaterThan(moment().unix());",
+											"    pm.expect(result.server).to.be.eq(\"rs.iudx.io\");",
+											"",
+											"    pm.environment.set(\"INTROSPECT_TOKEN\", result.accessToken);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"itemId\": \"rs.iudx.io\",\n    \"itemType\": \"resource_server\",\n    \"role\": \"provider\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
+									"host": [
+										"{{AUTH_ENDPOINT}}"
+									],
+									"path": [
+										"auth",
+										"v1",
+										"token"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Introspect Provider resource_server token - [200]",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check response header\", function () {",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
+											"});",
+											"",
+											"pm.test(\"Check response body\", function () {    ",
+											"    const body = pm.response.json();",
+											"    const moment = require('moment');",
+											"",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
+											"    const result = body.results;",
+											"    pm.expect(result).to.have.property(\"sub\");",
+											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
+											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
+											"    pm.expect(result.iid).to.be.eq(\"rs:rs.iudx.io\");",
+											"    pm.expect(result.role).to.be.eq(\"provider\");",
+											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
+											"    pm.expect(result.cons).to.be.empty;",
+											"    ",
+											"    pm.expect(result.userInfo).to.exist;",
+											"    const userInfo = result.userInfo;",
+											"    pm.expect(userInfo.email).to.be.eq(\"postman.provider-admin@datakaveri.org\");",
+											"    pm.expect(userInfo).to.have.property(\"name\");    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"accessToken\" : \"{{INTROSPECT_TOKEN}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{AUTH_ENDPOINT}}/auth/v1/introspect",
+									"host": [
+										"{{AUTH_ENDPOINT}}"
+									],
+									"path": [
+										"auth",
+										"v1",
+										"introspect"
+									]
+								}
+							},
+							"response": []
+						},
 						{
 							"name": "Provider role - Cannot get catalogue token - [403] (no cat admin policy)",
 							"event": [
@@ -8338,6 +8472,11 @@
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
+											"    ",
+											"    pm.expect(result.userInfo).to.exist;",
+											"    const userInfo = result.userInfo;",
+											"    pm.expect(userInfo.email).to.be.eq(\"consumer@gmail.com\");",
+											"    pm.expect(userInfo).to.have.property(\"name\");    ",
 											"});"
 										],
 										"type": "text/javascript"
@@ -13086,6 +13225,9 @@
 											"    pm.expect(result.role).to.be.eq(\"provider\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
+											"",
+											"    pm.expect(result.userInfo).to.not.exist;",
+											"",
 											"});"
 										],
 										"type": "text/javascript"
@@ -13415,6 +13557,8 @@
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.not.be.empty;",
+											"",
+											"    pm.expect(result.userInfo).to.not.exist;",
 											"});"
 										],
 										"type": "text/javascript"
@@ -16644,6 +16788,8 @@
 											"    pm.expect(result.role).to.be.eq(\"delegate\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
+											"",
+											"    pm.expect(result.userInfo).to.not.exist;",
 											"});"
 										],
 										"type": "text/javascript"


### PR DESCRIPTION
- User details (email, first name, last name) will be sent back in a key `userInfo` when an identity token (item type is resource_server)

TokenVerticle
-------------
- Added dependency to RegistrationService

TokenServiceImpl
----------------
- Updated constructor
- Updated `validateToken` method to handle getting user details
- Added method `addUserInfoToIntrospect` to call RegistrationService and add user details when required

TokenServiceTest
----------------
- Added tests to assert `userInfo` present in identity token introspection and not present otherwise

Integration Tests
-----------------
- Added and updated tests to check for presence or absence of `userInfo`