### PR TITLE
Make cat server item API path configurable

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -44,7 +44,8 @@
       "domain" : "iudx.io.test",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io.test",
-        "catServerPort": "443"
+        "catServerPort": "443",
+        "catServerItemPath": "/iudx/cat/v1/item"
       },
       "authOptions": {
         "policyExpiry" : "12",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -44,7 +44,8 @@
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443"
+        "catServerPort": "443",
+        "catServerItemPath": "/iudx/cat/v1/item"
       },
       "authOptions": {
         "policyExpiry" : "12",

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -44,7 +44,8 @@
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443"
+        "catServerPort": "443",
+        "catServerItemPath": "/iudx/cat/v1/item"
       },
       "authOptions": {
         "policyExpiry" : "12",

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -44,7 +44,8 @@
       "domain" : "iudx.io",
       "catalogueOptions": {
         "catServerHost": "api.catalogue.iudx.io",
-        "catServerPort": "443"
+        "catServerPort": "443",
+        "catServerItemPath": "/iudx/cat/v1/item"
       },
       "authOptions": {
         "policyExpiry" : "12",

--- a/src/main/java/iudx/aaa/server/policy/CatalogueClient.java
+++ b/src/main/java/iudx/aaa/server/policy/CatalogueClient.java
@@ -84,7 +84,7 @@ public class CatalogueClient {
     this.client = WebClient.create(vertx, clientOptions);
     this.catHost = options.getString("catServerHost");
     this.catPort = Integer.parseInt(options.getString("catServerPort"));
-    this.catItemPath = Constants.CAT_ITEM_PATH;
+    this.catItemPath = options.getString("catServerItemPath");
     this.authUrl = options.getString("authServerUrl");
     this.resUrl = options.getString("resURL");
     this.domain = options.getString("domain");

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -59,7 +59,6 @@ public class Constants {
   public static final String CALL_APD_CONTEXT = "context";
 
   public static final String RESULTS = "results";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
   public static final String PROVIDER_ID = "provider_id";
   public static final String NIL_UUID = "00000000-0000-0000-0000-000000000000";
 


### PR DESCRIPTION
- Since different cat servers may exist and the `iudx` path of the API may change depending on the deployment