### PR TITLE
Temporary Catalogue ID migration - use UUID instead of email-SHA ID for all APIs that take `itemId`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
           sh 'docker compose -f docker-compose-test.yml up test'
         }
         xunit (
-          thresholds: [ skipped(failureThreshold: '0'), failed(failureThreshold: '0') ],
+          thresholds: [ skipped(failureThreshold: '14'), failed(failureThreshold: '0') ],
           tools: [ JUnit(pattern: 'target/surefire-reports/*.xml') ]
         )
         jacoco classPattern: 'target/classes', execPattern: 'target/jacoco.exec', sourcePattern: 'src/main/java', exclusionPattern:'**/*VertxEBProxy.class,**/Constants.class,**/*VertxProxyHandler.class,**/*Verticle.class,iudx/aaa/server/deploy/*.class,iudx/aaa/server/registration/KcAdmin.class,iudx/aaa/server/apiserver/*,iudx/aaa/server/apiserver/util/*,iudx/aaa/server/admin/AdminService.class,iudx/aaa/server/apd/ApdService.class,iudx/aaa/server/auditing/AuditingService.class,iudx/aaa/server/auditing/AuditingService.class,iudx/aaa/server/registration/RegistrationService.class,iudx/aaa/server/token/TokenService.class,iudx/aaa/server/policy/PolicyService.class'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -217,7 +217,7 @@ paths:
             examples:
               Consumer requesting resource group:
                 value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm
+                  itemId: a007f760-8580-4401-81c1-b123da3de06f
                   itemType: resource_group
                   role: consumer
               Consumer requesting resource server (for access to public resources):
@@ -227,17 +227,17 @@ paths:
                   role: consumer
               Consumer requesting resource:
                 value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm/184ba502-22a8-ad15-a8f1-c966cd3aa7a7
+                  itemId: 31b3da3a-84da-4923-b425-a9c5469c169f
                   itemType: resource
                   role: consumer
               Provider requesting resource group:
                 value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm
+                  itemId: a007f760-8580-4401-81c1-b123da3de06f
                   itemType: resource_group
                   role: provider
               Delegate requesting for resource:
                 value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm/184ba502-22a8-ad15-a8f1-c966cd3aa7a7
+                  itemId: 31b3da3a-84da-4923-b425-a9c5469c169f
                   itemType: resource
                   role: delegate
               Admin of RS requesting resource server:
@@ -245,11 +245,6 @@ paths:
                   itemId: rs.iudx.org.in
                   itemType: resource_server
                   role: admin
-              Delegate requesting catalogue token:
-                value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/catalogue.iudx.org.in/catalogue/crud
-                  itemType: resource
-                  role: delegate
               identity token for APD as consumer:
                 value:
                   itemId: apd.iudx.org.in
@@ -267,7 +262,7 @@ paths:
                   role: provider
               Requesting resource with context object in body:
                 value:
-                  itemId: datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm
+                  itemId: a007f760-8580-4401-81c1-b123da3de06f
                   itemType: resource_group
                   role: consumer
                   context:
@@ -275,7 +270,7 @@ paths:
                     accessType: PERMANENT_ACCESS
         description: |-
           - `itemId` : the string value of the id of the resource
-            - e.g. `datakaveri.org/facec5182e3bf44cc3ac42b0b611263676d668a2/rs.iudx.org.in/agartala-env-aqm`
+            - e.g. `31b3da3a-84da-4923-b425-a9c5469c169f`
           - `itemType` : the kind of item the desired resource is
           - `role` : the role as which the user wants to get token for
           - `context` : a JSON object containing any extra information. The user may use this field to convey information to an APD in case the requested resource is backed by an APD policy
@@ -303,13 +298,6 @@ paths:
            - users with the `provider` role can get tokens for all of the resources that belong to them without having to set any specific policies to access them.
            - If the provider wishes to get a token to access a particular server, they require a **policy by the server admin**.
             
-        e.g.  A provider can get a token for the IUDX catalogue server by using the `itemId` as `<provider-domain>/<SHA1-of-provider-email>/<catalogue-url>/catalogue/crud`
-
-        For example, if the provider is *provider.foobar@datakaveri.org*, the `itemId` will be
-        ```
-        datakaveri.org/49276e9045a8a4c5c5bcc5b3b6923786896ff02d/catalogue.iudx.org.in/catalogue/crud
-        ```
-           
           ## Tokens for delegates
           - Valid item types - `resource`, `resource_group` 
           - Users with the `delegate` role can get tokens for resources if they:
@@ -317,8 +305,6 @@ paths:
              2. Have a policy set by the provider to access the resource 
              3. Must have a valid policy set by the admin of the server
 
-        **Note**: The IUDX Catalogue server does not require a policy to be set by the provider (2nd point).
-           
           ## Tokens for consumers
           - Valid item types - `resource`, `resource_group`, `resource_server`
           - Consumers can access the private resources for which they have a policy set by either the `provider` or by a `delegate`.
@@ -395,7 +381,7 @@ paths:
                       aud: foobar.iudx.io
                       exp: 1626837909
                       iat: 1626794709
-                      iid: 'rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95210v/resource-group'
+                      iid: 'rg:ae7f7313-61d9-46ab-9c33-7adc457ff0ed'
                       role: consumer
                       cons: {}
                 properties:
@@ -453,7 +439,7 @@ paths:
                       aud: rs.iudx.org.in
                       exp: 1634233203
                       iat: 1634190003
-                      iid: 'rg:datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.org.in/pune-env-aqm'
+                      iid: 'rg:a007f760-8580-4401-81c1-b123da3de06f'
                       role: consumer
                       cons:
                         access:
@@ -2330,7 +2316,7 @@ paths:
                         constraints:
                           access:
                             - sub
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood
+                        itemId: 5b7556b5-0779-4c47-9cf2-3f209779aa22
                         user:
                           email: vasanth.rajaraman@datakaveri.org
                           name:
@@ -2352,7 +2338,7 @@ paths:
                         itemType: resource
                         expiryTime: '2022-09-09T04:22:36'
                         constraints: {}
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-information/surat-itms-live-eta
+                        itemId: 83c2e5c2-3574-4e11-9530-2b1fbdfce832
                         user:
                           email: kailash.adhikari@india.nec.com
                           name:
@@ -2397,7 +2383,7 @@ paths:
                         itemType: resource_group
                         expiryTime: '2027-03-22T00:00'
                         constraints: {}
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/sub-sample
+                        itemId: f8947fec-191d-4f54-836f-fccca9ff9dbd
                         owner:
                           email: provider@datakaveri.org
                           name:
@@ -2695,12 +2681,12 @@ paths:
                 example-1:
                   request:
                     - userId: 89bbe934-5f18-4f57-b68e-fb821ba77291
-                      itemId: example.com/79e7bfa62fad6c765bac69154c2f24c94c95220a/resource-group
+                      itemId: ae7f7313-61d9-46ab-9c33-7adc457ff0ed
                       itemType: resource_group
                       expiryTime: '2023-08-30T21:10:06.834292'
                       constraints: {}
                     - userId: 89bbe934-5f18-4f57-b68e-fb821ba77292
-                      itemId: example.com/79e7bfa62fad6c765bac69154c2f24c94c95220a/resource-group
+                      itemId: ae7f7313-61d9-46ab-9c33-7adc457ff0ed
                       itemType: resource_group
                       expiryTime: '2023-08-30T21:10:06.834292'
                       constraints: {}
@@ -2781,7 +2767,7 @@ paths:
                 value:
                   request:
                     - userId: b34eb955-c691-4fd3-b200-f18bc78810a2
-                      itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood
+                      itemId: 5b7556b5-0779-4c47-9cf2-3f209779aa22
                       itemType: resource_group
                       expiryTime: '2022-08-04T20:00:19'
                       constraints:
@@ -2791,7 +2777,7 @@ paths:
                 value:
                   request:
                     - userId: b34eb955-c691-4fd3-b200-f18bc78810a2
-                      itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR056
+                      itemId: 7bca861b-d27a-4eff-b6b8-1f1173478e23
                       itemType: resource
                       expiryTime: '2022-10-10T04:00:19'
                       constraints:
@@ -2810,12 +2796,12 @@ paths:
                 value:
                   request:
                     - userId: b34eb955-c691-4fd3-b200-f18bc78810a2
-                      itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood
+                      itemId: 5b7556b5-0779-4c47-9cf2-3f209779aa22
                       itemType: resource_group
                       expiryTime: '2022-08-04T20:00:19'
                       constraints: {}
                     - userId: b34eb955-c691-4fd3-b200-f18bc78810a2
-                      itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR056
+                      itemId: 7bca861b-d27a-4eff-b6b8-1f1173478e23
                       itemType: resource
                       expiryTime: '2022-10-10T04:00:19'
                       constraints:
@@ -2835,7 +2821,7 @@ paths:
                   request:
                     - apdId: apd-testing.datakaveri.org
                       userClass: TestUserClass
-                      itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-info
+                      itemId: 8b95ab80-2aaf-4636-a65e-7f2563d0d371
                       itemType: resource_group
                       constraints:
                         access:
@@ -3416,7 +3402,7 @@ paths:
                     title: Access requests
                     results:
                       - requestId: ea48d233-5d3b-4bdb-9545-691680c99cee
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR056
+                        itemId: 7bca861b-d27a-4eff-b6b8-1f1173478e23
                         itemType: resource
                         status: pending
                         expiryDuration: P1Y2M10DT2H30M
@@ -3532,7 +3518,7 @@ paths:
                     title: Access requests
                     results:
                       - requestId: bd5f0bb3-c02c-4e3d-b75c-a6eb8144bddc
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR056
+                        itemId: 7bca861b-d27a-4eff-b6b8-1f1173478e23
                         itemType: resource
                         status: pending
                         expiryDuration: P1Y2M10DT2H30M
@@ -3607,7 +3593,7 @@ paths:
               x-examples:
                 example-1:
                   request:
-                    - itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR03
+                    - itemId: d271d832-bf3a-4f33-99e1-91bd4a1ee0dd
                       itemType: resource
                       expiryDuration: P1Y2M10DT2H30M
                       constraints: {}
@@ -3648,7 +3634,7 @@ paths:
               Create:
                 value:
                   request:
-                    - itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR035
+                    - itemId: d271d832-bf3a-4f33-99e1-91bd4a1ee0dd
                       itemType: resource
                       expiryDuration: P1Y2M10DT2H30M
                       constraints:
@@ -3696,7 +3682,7 @@ paths:
                     title: Access requests
                     results:
                       - requestId: bd5f0bb3-c02c-4e3d-b75c-a6eb8144bddc
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR056
+                        itemId: 7bca861b-d27a-4eff-b6b8-1f1173478e23
                         itemType: resource
                         status: approved
                         expiryDuration: P1Y2M10DT2H30M
@@ -3913,7 +3899,7 @@ paths:
                     title: deleted requests
                     results:
                       - requestId: 383ea497-0de9-4d6f-94c1-e3dd1328d944
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/integration-test
+                        itemId: e63e8e70-02e9-4c1a-8378-b0ea9f435789
                         itemType: resource_group
                         status: withdrawn
                         expiryDuration: '1 year 2 mons 10 days 02:30:00'
@@ -3941,7 +3927,7 @@ paths:
                     title: deleted requests
                     results:
                       - requestId: 383ea497-0de9-4d6f-94c1-e3dd1328d944
-                        itemId: iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/integration-test
+                        itemId: e63e8e70-02e9-4c1a-8378-b0ea9f435789
                         itemType: resource_group
                         status: withdrawn
                         expiryDuration: '1 year 2 mons 10 days 02:30:00'

--- a/src/main/java/iudx/aaa/server/policy/Constants.java
+++ b/src/main/java/iudx/aaa/server/policy/Constants.java
@@ -166,7 +166,7 @@ public class Constants {
       "select a.id,a.url,a.owner_id from resource_server a inner join ";
 
   public static final String GET_RES_SER_OWNER_JOIN =
-      " b on a.id = b.resource_server_id where b.cat_id = $1::text";
+      " b on a.id = b.resource_server_id where b.id = $1::UUID";
 
   public static final String CHECK_ADMIN_POLICY =
       "select id from policies where "
@@ -226,8 +226,8 @@ public class Constants {
           + "where owner_id = $1::UUID and url = ANY($2::text[])";
 
 
-  public static final String CHECK_RESOURCE_EXIST = "select cat_id from ";
-  public static final String CHECK_RESOURCE_EXIST_JOIN = " where cat_id = ANY($1::text[]) ";
+  public static final String CHECK_RESOURCE_EXIST = "select id from ";
+  public static final String CHECK_RESOURCE_EXIST_JOIN = " where id = ANY($1::uuid[]) ";
   public static final String CHECK_AUTH_POLICY =
       "select a.id from policies a inner join resource_server b "
           + " on a.item_id = b.id where a.user_id = $1::UUID and "
@@ -239,10 +239,10 @@ public class Constants {
                   "and expiry_time > now() and  item_id = ANY($3::UUID[])";
 
   public static final String GET_RES_GRP_DETAILS =
-      "select id,cat_id ,provider_id as owner_id, resource_server_id from resource_group where cat_id = ANY($1::text[]) ";
+      "select id,cat_id ,provider_id as owner_id, resource_server_id from resource_group where id = ANY($1::UUID[])";
 
   public static final String GET_RES_DETAILS =
-      "select id,cat_id ,provider_id as owner_id,resource_group_id, resource_server_id from resource where cat_id = ANY($1::text[]) ";
+      "select id,cat_id ,provider_id as owner_id,resource_group_id, resource_server_id from resource where id = ANY($1::UUID[])";
 
   public static final String GET_RES_SER_ID =
       "select url,id from resource_server where url = any($1::text[])";

--- a/src/main/java/iudx/aaa/server/policy/EmailClient.java
+++ b/src/main/java/iudx/aaa/server/policy/EmailClient.java
@@ -100,7 +100,7 @@ public class EmailClient {
             resourceObj -> {
               UUID providerId = resourceObj.getOwnerId();
               JsonObject provider = emailInfo.getUserInfo(providerId.toString());
-              String catId = resourceObj.getCatId();
+              String catId = resourceObj.getId().toString();
               List<UUID> authDelegates =
                   emailInfo.getProviderIdToAuthDelegateId().get(providerId.toString());
               List<String> ccEmailIds = new ArrayList<>();

--- a/src/test/java/iudx/aaa/server/policy/CreateApdPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreateApdPolicyTest.java
@@ -90,7 +90,6 @@ public class CreateApdPolicyTest {
   private static String otherServerURL;
   private static UUID apdId;
   private static UUID resourceGrpID;
-  private static String resourceGrp;
   private static String apdURL;
   private static Vertx vertxObj;
   private static PolicyService policyService;
@@ -126,12 +125,6 @@ public class CreateApdPolicyTest {
     authServerURL = "auth" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
     otherServerURL = "other" + RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
     apdURL = "apd."+ RandomStringUtils.randomAlphabetic(5).toLowerCase() + ".iudx.io";
-    resourceGrp = RandomStringUtils.randomAlphabetic(2)
-        + "/"
-        + RandomStringUtils.randomAlphabetic(2)
-        + "/"
-        + RandomStringUtils.randomAlphabetic(2)+ "/"
-        + RandomStringUtils.randomAlphabetic(2);;
     authOptions.put("authServerUrl", authServerURL);
     /* Set Connection Object and schema */
     if (connectOptions == null) {
@@ -239,7 +232,8 @@ public class CreateApdPolicyTest {
                               providerUser.result(),
                               otherSerId,
                               resourceGrpID,
-                              resourceGrp))
+                              // putting some random value in cat ID 
+                              RandomStringUtils.randomAlphabetic(10)))
                   .compose(
                       pol ->
                           // policy for provider user by admin user for all servers
@@ -393,26 +387,21 @@ public class CreateApdPolicyTest {
             .name(userJson.getString("firstName"), userJson.getString("lastName"))
             .roles(List.of(Roles.PROVIDER))
             .build();
-    String itemId =
-        RandomStringUtils.randomAlphabetic(2)
-            + "/"
-            + RandomStringUtils.randomAlphabetic(2)
-            + "/"
-            + RandomStringUtils.randomAlphabetic(2)+ "/"
-            + RandomStringUtils.randomAlphabetic(2);
+    
+    UUID randomItemId =UUID.randomUUID();
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", itemId)
+            .put("cat_id", "")
             .put("itemType", "resource_group")
             .put("owner_id", providerUser.result().getString("userId"))
-            .put("id", UUID.randomUUID())
+            .put("id", randomItemId)
             .put("resource_group_id", UUID.randomUUID())
             .put("resource_server_id", otherSerId.toString());
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     String randomAPD = RandomStringUtils.randomAlphabetic(5);
@@ -429,7 +418,7 @@ public class CreateApdPolicyTest {
 
 
     JsonObject obj = new JsonObject();
-    obj.put("itemId",itemId).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
+    obj.put("itemId",randomItemId.toString()).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
         .put("userClass","").put("constraints",new JsonObject());
     List<CreatePolicyRequest> req =
         CreatePolicyRequest.jsonArrayToList(new JsonArray().add(obj));
@@ -462,19 +451,13 @@ public class CreateApdPolicyTest {
               .name(userJson.getString("firstName"), userJson.getString("lastName"))
               .roles(List.of(Roles.PROVIDER))
               .build();
-      String itemId =
-          RandomStringUtils.randomAlphabetic(2)
-              + "/"
-              + RandomStringUtils.randomAlphabetic(2)
-              + "/"
-              + RandomStringUtils.randomAlphabetic(2)+ "/"
-              + RandomStringUtils.randomAlphabetic(2);
+      UUID randomItemId = UUID.randomUUID();
 
       Response r =
           new Response.ResponseBuilder()
               .type(Urn.URN_INVALID_INPUT.toString())
               .title(ITEMNOTFOUND)
-              .detail(itemId)
+              .detail(randomItemId.toString())
               .status(400)
               .build();
       ComposeException exception = new ComposeException(r);
@@ -494,7 +477,7 @@ public class CreateApdPolicyTest {
 
 
       JsonObject obj = new JsonObject();
-      obj.put("itemId",itemId).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
+      obj.put("itemId",randomItemId.toString()).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
           .put("userClass","").put("constraints",new JsonObject());
       List<CreatePolicyRequest> req =
           CreatePolicyRequest.jsonArrayToList(new JsonArray().add(obj));
@@ -530,7 +513,7 @@ public class CreateApdPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceGrp)
+            .put("cat_id", "")
             .put("itemType", "resource_group")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id",resourceGrpID)
@@ -539,7 +522,7 @@ public class CreateApdPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     String randomAPD = RandomStringUtils.randomAlphabetic(5);
@@ -566,7 +549,7 @@ public class CreateApdPolicyTest {
         .getApdDetails(any(), any(), any());
 
     JsonObject obj = new JsonObject();
-    obj.put("itemId",resourceGrp).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
+    obj.put("itemId",resourceGrpID.toString()).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
         .put("userClass","").put("constraints",new JsonObject());
     List<CreatePolicyRequest> req =
         CreatePolicyRequest.jsonArrayToList(new JsonArray().add(obj));
@@ -602,7 +585,7 @@ public class CreateApdPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceGrp)
+            .put("cat_id", "")
             .put("itemType", "resource_group")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id",resourceGrpID)
@@ -611,7 +594,7 @@ public class CreateApdPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     String randomAPD = RandomStringUtils.randomAlphabetic(5);
@@ -638,7 +621,7 @@ public class CreateApdPolicyTest {
         .getApdDetails(any(), any(), any());
 
     JsonObject obj = new JsonObject();
-    obj.put("itemId",resourceGrp).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
+    obj.put("itemId",resourceGrpID.toString()).put("itemType","RESOURCE_GROUP").put("apdId",randomAPD)
         .put("userClass","").put("constraints",new JsonObject());
     List<CreatePolicyRequest> req =
         CreatePolicyRequest.jsonArrayToList(new JsonArray().add(obj));

--- a/src/test/java/iudx/aaa/server/policy/CreateUserPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/CreateUserPolicyTest.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,9 +97,7 @@ public class CreateUserPolicyTest {
   private static UUID resourceGrpID;
   private static UUID resourceIdOne;
   private static UUID resourceIdTwo;
-  private static String resourceGrp;
-  private static String resourceOne;
-  private static String resourceTwo;
+
   private static Vertx vertxObj;
   private static PolicyService policyService;
   private static ApdService apdService = Mockito.mock(ApdService.class);
@@ -224,9 +223,6 @@ public class CreateUserPolicyTest {
               resourceGrpID = UUID.randomUUID();
               resourceIdOne = UUID.randomUUID();
               resourceIdTwo = UUID.randomUUID();
-              resourceGrp = "emailsha/xyz/" + otherServerURL + "/rsg";
-              resourceOne = resourceGrp + "/ri1";
-              resourceTwo = resourceGrp + "/ri2";
               Utils.createFakeResourceServer(pgclient, adminUser.result(), authSerId, authServerURL)
                   .compose(
                       comp ->
@@ -243,7 +239,8 @@ public class CreateUserPolicyTest {
                               providerUser.result(),
                               otherSerId,
                               resourceGrpID,
-                              resourceGrp))
+                              // putting some random value in cat ID 
+                              RandomStringUtils.randomAlphabetic(10)))
                   .compose(
                       comp ->
                           Utils.createFakeResource(
@@ -252,7 +249,8 @@ public class CreateUserPolicyTest {
                               resourceIdOne,
                               otherSerId,
                               resourceGrpID,
-                              resourceOne))
+                              // putting some random value in cat ID 
+                              RandomStringUtils.randomAlphabetic(10)))
                   .compose(
                       comp ->
                           Utils.createFakeResource(
@@ -261,7 +259,8 @@ public class CreateUserPolicyTest {
                               resourceIdTwo,
                               otherSerId,
                               resourceGrpID,
-                              resourceTwo))
+                              // putting some random value in cat ID 
+                              RandomStringUtils.randomAlphabetic(10)))
                   .compose(
                       pol ->
                           // policy for provider user by admin user for all servers
@@ -415,8 +414,8 @@ public class CreateUserPolicyTest {
             .name(userJson.getString("firstName"), userJson.getString("lastName"))
             .roles(List.of(Roles.PROVIDER))
             .build();
-    String invalidCatId =
-        "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/invalidRes";
+    String invalidCatId = UUID.randomUUID().toString();
+    
     Response r =
         new Response.ResponseBuilder()
             .type(Urn.URN_INVALID_INPUT.toString())
@@ -505,7 +504,7 @@ public class CreateUserPolicyTest {
     JsonObject userFailReq =
         new JsonObject()
             .put("userId", UUID.randomUUID())
-            .put("itemId", resourceGrp)
+            .put("itemId", resourceGrpID.toString())
             .put("itemType", "resource_group")
             .put("expiryTime", "")
             .put("constraints", new JsonObject());
@@ -514,7 +513,7 @@ public class CreateUserPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceOne)
+            .put("cat_id", "")
             .put("itemType", "resource")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id", resourceIdOne.toString())
@@ -523,7 +522,7 @@ public class CreateUserPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
     policyService.createPolicy(
         userFailReqItem,
@@ -556,7 +555,7 @@ public class CreateUserPolicyTest {
     JsonObject polExpFail =
         new JsonObject()
             .put("userId", consumerUser.result().getString("userId"))
-            .put("itemId", resourceGrp)
+            .put("itemId", resourceGrpID.toString())
             .put("itemType", "resource_group")
             .put("expiryTime", "2010-01-01T01:01:01")
             .put("constraints", new JsonObject());
@@ -565,7 +564,7 @@ public class CreateUserPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceOne)
+            .put("cat_id", "")
             .put("itemType", "resource")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id", resourceIdOne.toString())
@@ -574,7 +573,7 @@ public class CreateUserPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
     policyService.createPolicy(
         userFailReqItem,
@@ -605,7 +604,7 @@ public class CreateUserPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceGrp)
+            .put("cat_id", "")
             .put("itemType", "resource_group")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id", resourceGrpID.toString())
@@ -613,13 +612,13 @@ public class CreateUserPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     JsonObject reqItem =
         new JsonObject()
             .put("userId", consumerUser.result().getString("userId"))
-            .put("itemId", resourceGrp)
+            .put("itemId", resourceGrpID.toString())
             .put("itemType", "resource_group")
             .put("expiryTime", "")
             .put("constraints", new JsonObject());
@@ -655,7 +654,7 @@ public class CreateUserPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceGrp)
+            .put("cat_id", "")
             .put("itemType", "resource_group")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id", resourceGrpID.toString())
@@ -663,13 +662,13 @@ public class CreateUserPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     JsonObject reqItem =
         new JsonObject()
             .put("userId", consumerUser.result().getString("userId"))
-            .put("itemId", resourceGrp)
+            .put("itemId", resourceGrpID.toString())
             .put("itemType", "resource_group")
             .put("expiryTime", "")
             .put("constraints", new JsonObject());
@@ -707,7 +706,7 @@ public class CreateUserPolicyTest {
       JsonObject validReq =
           new JsonObject()
               .put("userId", consumerUser.result().getString("userId"))
-              .put("itemId", resourceTwo)
+              .put("itemId", resourceIdTwo.toString())
               .put("itemType", "resource")
               .put("expiryTime", "")
               .put("constraints", new JsonObject());
@@ -745,7 +744,7 @@ public class CreateUserPolicyTest {
 
     JsonObject validCatItem =
         new JsonObject()
-            .put("cat_id", resourceOne)
+            .put("cat_id", "")
             .put("itemType", "resource")
             .put("owner_id", providerUser.result().getString("userId"))
             .put("id", resourceIdOne.toString())
@@ -754,13 +753,13 @@ public class CreateUserPolicyTest {
 
     ResourceObj resourceObj = new ResourceObj(validCatItem);
     Map<String, ResourceObj> resp = new HashMap<>();
-    resp.put(resourceObj.getCatId(), resourceObj);
+    resp.put(resourceObj.getId().toString(), resourceObj);
     Mockito.when(catalogueClient.checkReqItems(any())).thenReturn(Future.succeededFuture(resp));
 
     JsonObject validReq =
         new JsonObject()
             .put("userId", consumerUser.result().getString("userId"))
-            .put("itemId", resourceOne)
+            .put("itemId", resourceIdOne.toString())
             .put("itemType", "resource")
             .put("expiryTime", "")
             .put("constraints", new JsonObject());
@@ -782,6 +781,7 @@ public class CreateUserPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("Testing Failure for RES_Grp(Item does not exist))")
   void itemFailure4Resgp(VertxTestContext testContext) {
@@ -829,6 +829,7 @@ public class CreateUserPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("Testing Failure for RES_Id(Item does not exist))")
   void itemFailure4ResId(VertxTestContext testContext) {

--- a/src/test/java/iudx/aaa/server/policy/DeletePolicyNotificationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/DeletePolicyNotificationTest.java
@@ -510,20 +510,6 @@ public class DeletePolicyNotificationTest {
                                           .roles(List.of(Roles.CONSUMER))
                                           .build();
 
-                          /* Mock catalogue client for itemIds for UUID */
-                          Mockito.doAnswer(
-                                  i -> {
-                                      Set<UUID> itemIds = i.getArgument(0);
-                                      Map<UUID, String> map = new HashMap<UUID, String>();
-                                      itemIds.forEach(
-                                              item -> {
-                                                  map.put(item, RandomStringUtils.randomAlphabetic(5));
-                                              });
-                                      return Future.succeededFuture(map);
-                                  })
-                                  .when(catalogueClient)
-                                  .getCatIds(Mockito.any(), Mockito.any());
-
                           /* Mock registration service user details */
                           Mockito.doAnswer(
                                   i -> {
@@ -577,20 +563,6 @@ public class DeletePolicyNotificationTest {
                       .name(userJson.getString("firstName"), userJson.getString("lastName"))
                       .roles(List.of(Roles.CONSUMER))
                       .build();
-
-              /* Mock catalogue client for itemIds for UUID */
-              Mockito.doAnswer(
-                      i -> {
-                        Set<UUID> itemIds = i.getArgument(0);
-                        Map<UUID, String> map = new HashMap<UUID, String>();
-                        itemIds.forEach(
-                            item -> {
-                              map.put(item, RandomStringUtils.randomAlphabetic(5));
-                            });
-                        return Future.succeededFuture(map);
-                      })
-                  .when(catalogueClient)
-                  .getCatIds(Mockito.any(), Mockito.any());
 
               /* Mock registration service user details */
               Mockito.doAnswer(
@@ -661,20 +633,6 @@ public class DeletePolicyNotificationTest {
                                                                 .name(userJson.getString("firstName"), userJson.getString("lastName"))
                                                                 .roles(List.of(Roles.CONSUMER))
                                                                 .build();
-
-                                                /* Mock catalogue client for itemIds for UUID */
-                                                Mockito.doAnswer(
-                                                        i -> {
-                                                            Set<UUID> itemIds = i.getArgument(0);
-                                                            Map<UUID, String> map = new HashMap<UUID, String>();
-                                                            itemIds.forEach(
-                                                                    item -> {
-                                                                        map.put(item, RandomStringUtils.randomAlphabetic(5));
-                                                                    });
-                                                            return Future.succeededFuture(map);
-                                                        })
-                                                        .when(catalogueClient)
-                                                        .getCatIds(Mockito.any(), Mockito.any());
 
                                                 /* Mock registration service user details */
                                                 Mockito.doAnswer(

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyNotificationTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyNotificationTest.java
@@ -133,15 +133,6 @@ public class ListPolicyNotificationTest {
   static UUID providerAResItemId = UUID.randomUUID();
   static UUID providerBResItemId = UUID.randomUUID();
 
-  static String providerARsgCatId = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-  static String providerBRsgCatId = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-  static String providerAResCatId = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-  static String providerBResCatId = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-
-  Map<UUID, String> itemIdToCatId =
-      Map.of(providerARsgItemId, providerARsgCatId, providerBRsgItemId, providerBRsgCatId,
-          providerAResItemId, providerAResCatId, providerBResItemId, providerBResCatId);
-
   Map<String, JsonObject> userDetails = new HashMap<String, JsonObject>();
 
   static Future<UUID> orgIdFut;
@@ -381,14 +372,6 @@ public class ListPolicyNotificationTest {
         .name(userJson.getString("firstName"), userJson.getString("lastName"))
         .roles(List.of(Roles.CONSUMER)).build();
 
-    /* Mock catalogue client to get correct list of cat IDs */
-    Mockito.doAnswer(i -> {
-      Set<UUID> itemIds = i.getArgument(0);
-      Map<UUID, String> resMap =
-          itemIds.stream().collect(Collectors.toMap(id -> id, id -> itemIdToCatId.get(id)));
-      return Future.succeededFuture(resMap);
-    }).when(catalogueClient).getCatIds(Mockito.any(), Mockito.any());
-
     /* Mock registration service details */
     Mockito.doAnswer(i -> {
       List<String> userIds = i.getArgument(0);
@@ -415,7 +398,7 @@ public class ListPolicyNotificationTest {
             JsonObject j = (JsonObject) object;
 
             if (j.getString("requestId").equals(request1.toString())) {
-              assertEquals(j.getString(ITEMID), providerARsgCatId);
+              assertEquals(j.getString(ITEMID), providerARsgItemId.toString());
               assertEquals(j.getString(STATUS),
                   NotifRequestStatus.PENDING.toString().toLowerCase());
               assertEquals(j.getString(ITEMTYPE), "resource_group");
@@ -429,7 +412,7 @@ public class ListPolicyNotificationTest {
             }
 
             if (j.getString("requestId").equals(request2.toString())) {
-              assertEquals(j.getString(ITEMID), providerBResCatId);
+              assertEquals(j.getString(ITEMID), providerBResItemId.toString());
               assertEquals(j.getString(STATUS),
                   NotifRequestStatus.APPROVED.toString().toLowerCase());
               assertEquals(j.getString(ITEMTYPE), "resource");
@@ -457,14 +440,6 @@ public class ListPolicyNotificationTest {
     // add mocks
     // must get requests 1 and 3
 
-    /* Mock catalogue client to get correct list of cat IDs */
-    Mockito.doAnswer(i -> {
-      Set<UUID> itemIds = i.getArgument(0);
-      Map<UUID, String> resMap =
-              itemIds.stream().collect(Collectors.toMap(id -> id, id -> itemIdToCatId.get(id)));
-      return Future.succeededFuture(resMap);
-    }).when(catalogueClient).getCatIds(Mockito.any(), Mockito.any());
-
     /* Mock registration service details */
     Mockito.doAnswer(i -> {
       List<String> userIds = i.getArgument(0);
@@ -491,7 +466,7 @@ public class ListPolicyNotificationTest {
                 JsonObject j = (JsonObject) object;
 
                 if (j.getString("requestId").equals(request1.toString())) {
-                  assertEquals(j.getString(ITEMID), providerARsgCatId);
+                  assertEquals(j.getString(ITEMID), providerARsgItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.PENDING.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource_group");
@@ -505,7 +480,7 @@ public class ListPolicyNotificationTest {
                 }
 
                 if (j.getString("requestId").equals(request3.toString())) {
-                  assertEquals(j.getString(ITEMID), providerAResCatId);
+                  assertEquals(j.getString(ITEMID), providerAResItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.REJECTED.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource");
@@ -534,14 +509,6 @@ public class ListPolicyNotificationTest {
     // add mocks
     // must get requests 2 and 4
 
-    /* Mock catalogue client to get correct list of cat IDs */
-    Mockito.doAnswer(i -> {
-      Set<UUID> itemIds = i.getArgument(0);
-      Map<UUID, String> resMap =
-              itemIds.stream().collect(Collectors.toMap(id -> id, id -> itemIdToCatId.get(id)));
-      return Future.succeededFuture(resMap);
-    }).when(catalogueClient).getCatIds(Mockito.any(), Mockito.any());
-
     /* Mock registration service details */
     Mockito.doAnswer(i -> {
       List<String> userIds = i.getArgument(0);
@@ -568,7 +535,7 @@ public class ListPolicyNotificationTest {
                 JsonObject j = (JsonObject) object;
 
                 if (j.getString("requestId").equals(request4.toString())) {
-                  assertEquals(j.getString(ITEMID), providerBRsgCatId);
+                  assertEquals(j.getString(ITEMID), providerBRsgItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.PENDING.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource_group");
@@ -582,7 +549,7 @@ public class ListPolicyNotificationTest {
                 }
 
                 if (j.getString("requestId").equals(request2.toString())) {
-                  assertEquals(j.getString(ITEMID), providerBResCatId);
+                  assertEquals(j.getString(ITEMID), providerBResItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.APPROVED.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource");
@@ -610,14 +577,6 @@ public class ListPolicyNotificationTest {
     // add mocks
     // must get requests 3 and 4
 
-    /* Mock catalogue client to get correct list of cat IDs */
-    Mockito.doAnswer(i -> {
-      Set<UUID> itemIds = i.getArgument(0);
-      Map<UUID, String> resMap =
-              itemIds.stream().collect(Collectors.toMap(id -> id, id -> itemIdToCatId.get(id)));
-      return Future.succeededFuture(resMap);
-    }).when(catalogueClient).getCatIds(Mockito.any(), Mockito.any());
-
     /* Mock registration service details */
     Mockito.doAnswer(i -> {
       List<String> userIds = i.getArgument(0);
@@ -644,7 +603,7 @@ public class ListPolicyNotificationTest {
                 JsonObject j = (JsonObject) object;
 
                 if (j.getString("requestId").equals(request4.toString())) {
-                  assertEquals(j.getString(ITEMID), providerBRsgCatId);
+                  assertEquals(j.getString(ITEMID), providerBRsgItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.PENDING.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource_group");
@@ -658,7 +617,7 @@ public class ListPolicyNotificationTest {
                 }
 
                 if (j.getString("requestId").equals(request3.toString())) {
-                  assertEquals(j.getString(ITEMID), providerAResCatId);
+                  assertEquals(j.getString(ITEMID), providerAResItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.REJECTED.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource");
@@ -691,14 +650,6 @@ public class ListPolicyNotificationTest {
     // add mocks
     // must get requests 1 and 3
 
-    /* Mock catalogue client to get correct list of cat IDs */
-    Mockito.doAnswer(i -> {
-      Set<UUID> itemIds = i.getArgument(0);
-      Map<UUID, String> resMap =
-              itemIds.stream().collect(Collectors.toMap(id -> id, id -> itemIdToCatId.get(id)));
-      return Future.succeededFuture(resMap);
-    }).when(catalogueClient).getCatIds(Mockito.any(), Mockito.any());
-
     /* Mock registration service details */
     Mockito.doAnswer(i -> {
       List<String> userIds = i.getArgument(0);
@@ -725,7 +676,7 @@ public class ListPolicyNotificationTest {
                 JsonObject j = (JsonObject) object;
 
                 if (j.getString("requestId").equals(request1.toString())) {
-                  assertEquals(j.getString(ITEMID), providerARsgCatId);
+                  assertEquals(j.getString(ITEMID), providerARsgItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.PENDING.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource_group");
@@ -739,7 +690,7 @@ public class ListPolicyNotificationTest {
                 }
 
                 if (j.getString("requestId").equals(request3.toString())) {
-                  assertEquals(j.getString(ITEMID), providerAResCatId);
+                  assertEquals(j.getString(ITEMID), providerAResItemId.toString());
                   assertEquals(j.getString(STATUS),
                           NotifRequestStatus.REJECTED.toString().toLowerCase());
                   assertEquals(j.getString(ITEMTYPE), "resource");

--- a/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/ListPolicyTest.java
@@ -132,15 +132,6 @@ public class ListPolicyTest {
   void listPolicySuccessProvider(VertxTestContext testContext) {
 
     Mockito.doAnswer(i -> {
-      Map<UUID, String> result = new HashMap<UUID, String>();
-      Set<UUID> ids = i.getArgument(0);
-      for (UUID x : ids) {
-        result.put(x, "<cat-id-placeholder>");
-      }
-      return Future.succeededFuture(result);
-    }).when(catalogueClient).getCatIds(any(), any());
-
-    Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(2);
       JsonObject result = new JsonObject();
       List<String> ids = i.getArgument(1);
@@ -173,15 +164,6 @@ public class ListPolicyTest {
   @Test
   @DisplayName("ListPolicy Success consumer")
   void listPolicySuccessConsumer(VertxTestContext testContext) {
-
-    Mockito.doAnswer(i -> {
-      Map<UUID, String> result = new HashMap<UUID, String>();
-      Set<UUID> ids = i.getArgument(0);
-      for (UUID x : ids) {
-        result.put(x, "<cat-id-placeholder>");
-      }
-      return Future.succeededFuture(result);
-    }).when(catalogueClient).getCatIds(any(), any());
 
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(2);

--- a/src/test/java/iudx/aaa/server/policy/TestRequest.java
+++ b/src/test/java/iudx/aaa/server/policy/TestRequest.java
@@ -20,7 +20,7 @@ public class TestRequest {
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg")
+              "a57cdc77-44a3-44b9-ba39-f339e40d3d21")
           .put("itemType", "resource_group")
           .put("role", "consumer")
           .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
@@ -29,7 +29,7 @@ public class TestRequest {
           new JsonObject()
                   .put(
                           "itemId",
-                          "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg")
+                          "a57cdc77-44a3-44b9-ba39-f339e40d3d21")
                   .put("itemType", "RESOURCE_SERVER")
                   .put("role", "consumer")
                   .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
@@ -37,7 +37,7 @@ public class TestRequest {
           new JsonObject()
                   .put(
                           "itemId",
-                          "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg")
+                          "a57cdc77-44a3-44b9-ba39-f339e40d3d21")
                   .put("itemType", "ADMIN")
                   .put("role", "ADMIN")
                   .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
@@ -47,27 +47,27 @@ public class TestRequest {
           .put("itemId", "rs.iudx.io")
           .put("itemType", "resource_group")
           .put("role", "consumer")
-          .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
+          .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
 
   public static JsonObject invalidItemId2 =
           new JsonObject()
                   .put("itemId", "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg/rs.iudx.io/testing-insert-rsg/rs.iudx.io")
                   .put("itemType", "RESOURCE_GROUP")
                   .put("role", "consumer")
-                  .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
+                  .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
 
   public static JsonObject invalidItemId3 =
           new JsonObject()
                   .put("itemId", "iisc.ac.in/89a36273d7/rs.iudx.io/testing-insert-rsg")
                   .put("itemType", "RESOURCE")
                   .put("role", "consumer")
-                  .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");
+                  .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
 
   public static JsonObject consumerVerification =
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-information")
+              "8b95ab80-2aaf-4636-a65e-7f2563d0d371")
           .put("itemType", "resource_group")
           .put("role", "consumer")
           .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
@@ -76,7 +76,7 @@ public class TestRequest {
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/sub-sample")
+              "f8947fec-191d-4f54-836f-fccca9ff9dbd")
           .put("itemType", "resource_group")
           .put("role", "consumer")
           .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
@@ -103,7 +103,7 @@ public class TestRequest {
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-information")
+              "8b95ab80-2aaf-4636-a65e-7f2563d0d371")
           .put("itemType", "resource_group")
           .put("role", "provider")
           .put("userId", "b2c27f3f-2524-4a84-816e-91f9ab23f837");
@@ -112,7 +112,7 @@ public class TestRequest {
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg")
+              "a57cdc77-44a3-44b9-ba39-f339e40d3d21")
           .put("itemType", "resource_group")
           .put("role", "delegate")
           .put("userId", "e69debbb-4c49-4727-a779-e355414915c2");
@@ -130,7 +130,7 @@ public class TestRequest {
       new JsonObject()
           .put(
               "itemId",
-              "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/testing-insert-rsg")
+              "a57cdc77-44a3-44b9-ba39-f339e40d3d21")
           .put("itemType", "resource_group")
           .put("role", "delegate")
           .put("userId", "c5a34d2d-9553-4925-81fe-09aa08f29dea");

--- a/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
+++ b/src/test/java/iudx/aaa/server/policy/VerifyPolicyTest.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -170,7 +171,7 @@ public class VerifyPolicyTest {
                 testContext.verify(
                     () -> {
                       ComposeException exp = (ComposeException) response;
-                      assertEquals(INCORRECT_ITEM_ID, exp.getResponse().getDetail());
+                      assertEquals(invalidItemId.getString("itemId"), exp.getResponse().getDetail());
                       testContext.completeNow();
                     })));
   }
@@ -213,6 +214,7 @@ public class VerifyPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("no policy by catalogue admin")
   void NoAdminPolicy(VertxTestContext testContext) {
@@ -228,6 +230,7 @@ public class VerifyPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("Successful provider catalogue policy verification")
   void ProviderCatPolicySuccess(VertxTestContext testContext) {
@@ -271,6 +274,7 @@ public class VerifyPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("no policy for user by cat admin")
   void noCatAdminPolicy(VertxTestContext testContext) {
@@ -286,6 +290,7 @@ public class VerifyPolicyTest {
                     })));
   }
 
+  @Disabled
   @Test
   @DisplayName("testing successful delegate verification")
   void validCatVerification(VertxTestContext testContext) {
@@ -333,6 +338,7 @@ public class VerifyPolicyTest {
                                         })));
     }
 
+    @Disabled
     @Test
     @DisplayName("Resource Group !=4 Error")
     void invalidItemId2(VertxTestContext testContext) {
@@ -350,6 +356,7 @@ public class VerifyPolicyTest {
                                         })));
     }
 
+    @Disabled
     @Test
     @DisplayName("Resource <=4 Error")
     void invalidItemId3(VertxTestContext testContext) {

--- a/src/test/resources/Integration_Test.postman_collection.json
+++ b/src/test/resources/Integration_Test.postman_collection.json
@@ -7771,7 +7771,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"admin\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"admin\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7827,7 +7827,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"admin\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"admin\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7983,62 +7983,6 @@
 							"response": []
 						},
 						{
-							"name": "Provider role - Cannot get catalogue token - [403] (no cat admin policy)",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(403);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Provider role - Cannot get token for resource_group owned by postman.provider-admin - [403] (no rs admin policy)",
 							"event": [
 								{
@@ -8073,7 +8017,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8129,7 +8073,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8185,7 +8129,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8241,7 +8185,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8302,7 +8246,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8358,7 +8302,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8555,7 +8499,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8611,63 +8555,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delegate cannot get catalogue token - [400] (no admin policy + no delegation)",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(403);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -8719,7 +8607,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -8822,7 +8710,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-oneddatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-oneatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-onedatakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b84b367af2-ad55-4017-9e19-35a5fa37e9b84b367af2-ad55-4017-9e19-35a5fa37e9b84b367af2-ad55-4017-9e19-35a5fa37e9b84b367af2-ad55-4017-9e19-35a5fa37e9b8d4b367af2-ad55-4017-9e19-35a5fa37e9b84b367af2-ad55-4017-9e19-35a5fa37e9b8atakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -8934,7 +8822,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resourcklsa\",\n    \"role\": \"consumer\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resourcklsa\",\n    \"role\": \"consumer\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -8990,7 +8878,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"role\": \"consumer\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"role\": \"consumer\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9046,7 +8934,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\":\"resource_group\",\n    \"role\": \"consum\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\":\"resource_group\",\n    \"role\": \"consum\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9102,7 +8990,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\":\"resource_group\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\":\"resource_group\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9158,7 +9046,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\":\"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": \"hello\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\":\"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": \"hello\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9214,7 +9102,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9270,7 +9158,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9326,7 +9214,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -9451,7 +9339,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{$randomUUID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{$randomUUID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9509,7 +9397,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9567,7 +9455,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9625,7 +9513,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\", \"sub\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\", \"sub\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9683,7 +9571,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"3000-12-12T12:12:12\"\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"3000-12-12T12:12:12\"\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9741,7 +9629,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/fake-item/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n         {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/fake-item/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n         {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9799,7 +9687,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n                        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/9c13a2308bb0919bf146be8681eb886922d29282/rs.iudx.io/invalid-resource-for-ownership-test\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n         {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n                        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"decffa8a-a1ec-3a60-e571-cafedead5351\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n                {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        },\n         {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\":\"2030-12-12T00:00:00\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9857,7 +9745,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"file\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-12T00:00:00\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-12T00:00:00\"\n        },\n        {\n            \"userId\": \"{{REJPROVIDER_DELEGATE_USERID}}\",\n            \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"file\"\n                ]\n            }\n        },\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-12T00:00:00\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9915,7 +9803,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -9973,65 +9861,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{},\n        \"expiryTime\":\"2020-09-09T15:00:00\"\n    }]\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/policies",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"policies"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "INCORRECT!! Test catalogue fetch - [400]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(400);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"});",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{},\n        \"expiryTime\":\"2020-09-09T15:00:00\"\n    }]\n}",
+									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{},\n        \"expiryTime\":\"2020-09-09T15:00:00\"\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10210,7 +10040,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"746442f5-18a7-44fd-8c8f-3e39e5026fae\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"746442f5-18a7-44fd-8c8f-3e39e5026fae\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10268,7 +10098,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"746442f5-18a7-44fd-8c8f-3e39e5026fae\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"746442f5-18a7-44fd-8c8f-3e39e5026fae\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10620,7 +10450,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10676,63 +10506,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delegate cannot get catalogue token - [403] (No delegation)",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(403);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10800,7 +10574,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10863,7 +10637,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10926,7 +10700,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+									"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10984,7 +10758,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -11047,7 +10821,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -11110,7 +10884,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/9c13a2308bb0919bf146be8681eb886922d29282/rs.iudx.io/invalid-resource-for-ownership-test\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"decffa8a-a1ec-3a60-e571-cafedead5351\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -11173,7 +10947,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"datakaveri.org/9c13a2308bb0919bf146be8681eb886922d29282/rs.iudx.io/invalid-resource-for-ownership-test\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n        {\n            \"userId\": \"{{ALL_ROLES_USERID}}\",\n            \"itemId\": \"decffa8a-a1ec-3a60-e571-cafedead5351\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -11495,7 +11269,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"124443423242342433489327470283947028347284702847823842\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"124443423242342433489327470283947028347284702847823842\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11553,7 +11327,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11611,7 +11385,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8integration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-oneintegration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11727,7 +11501,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"roureabcd\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"roureabcd\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11785,7 +11559,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11843,7 +11617,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":\"90193023\"\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":\"90193023\"\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11901,7 +11675,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\"\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\"\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -11959,7 +11733,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"expiryTime\": \"2133231-23-232T90320\"\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"expiryTime\": \"2133231-23-232T90320\"\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12017,7 +11791,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"userClass\":\"something\"\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"userClass\":\"something\"\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12075,7 +11849,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\"\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\"\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12133,7 +11907,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\",\n            \"userClass\":\"something\"\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\",\n            \"userClass\":\"something\"\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12191,7 +11965,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\"\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {},\n            \"apdId\":\"example.com\"\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12249,7 +12023,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n                {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        },\n                {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"constraints\": {}\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12307,7 +12081,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12365,7 +12139,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
+							"raw": "{\n    \"request\": [{\n        \"userId\":\"{{CONSUMER_GMAIL_USERID}}\",\n        \"itemId\":\"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n        \"itemType\":\"resource_group\",\n        \"constraints\":{}\n    }]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12423,7 +12197,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -12608,7 +12382,7 @@
 									"        if(r.owner.id == \"746442f5-18a7-44fd-8c8f-3e39e5026fae\")",
 									"        {",
 									"            pm.expect(r.user.id).to.be.oneOf([pm.environment.get(\"CONSUMER_GMAIL_USERID\"),pm.environment.get(\"ALL_ROLES_USERID\"),pm.environment.get(\"REJPROVIDER_DELEGATE_USERID\")]);",
-									"            pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+									"            pm.expect(r.itemId).to.exist;",
 									"            pm.expect(r.constraints).to.exist;",
 									"            pm.expect(r.policyId).to.exist;",
 									"            pm.expect(r.expiryTime).to.exist;",
@@ -12675,7 +12449,7 @@
 									"            pm.expect(r.owner.id == \"746442f5-18a7-44fd-8c8f-3e39e5026fae\").to.be.true;",
 									"            pm.expect(r.user.id).to.be.eq(pm.environment.get(\"CONSUMER_GMAIL_USERID\"));",
 									"            pm.expect(r.user.email).to.be.eq(\"consumer@gmail.com\");",
-									"            pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+									"            pm.expect(r.itemId).to.exist;",
 									"            pm.expect(r.constraints).to.exist;",
 									"            pm.expect(r.policyId).to.exist;",
 									"            pm.expect(r.expiryTime).to.exist;",
@@ -12737,7 +12511,7 @@
 									"            pm.expect(r.user.id).to.be.eq(pm.environment.get(\"REJPROVIDER_DELEGATE_USERID\"));",
 									"            pm.expect(r.user.email).to.be.eq(\"rejprovider.delegate@datakaveri.org\");",
 									"            if([\"resource_group\", \"resource\"].includes(r.itemType))",
-									"                pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+									"                pm.expect(r.itemId).to.exist;",
 									"            if(r.itemType == 'resource_server')",
 									"                pm.expect(r.expiryTime.startsWith(\"3000\")).to.be.true;",
 									"            pm.expect(r.constraints).to.exist;",
@@ -12955,7 +12729,7 @@
 									"    body.results.forEach((r) =>{",
 									"        pm.expect(r.owner.id == \"746442f5-18a7-44fd-8c8f-3e39e5026fae\").to.be.true;",
 									"            pm.expect(r.user.id).to.be.oneOf([pm.environment.get(\"CONSUMER_GMAIL_USERID\"),pm.environment.get(\"ALL_ROLES_USERID\"),pm.environment.get(\"REJPROVIDER_DELEGATE_USERID\")]);",
-									"            pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+									"            pm.expect(r.itemId).to.be.exist;",
 									"            pm.expect(r.constraints).to.exist;",
 									"            pm.expect(r.itemType).to.exist;",
 									"            pm.expect(r.policyId).to.exist;",
@@ -13046,7 +12820,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13091,7 +12865,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 											"    pm.expect(result.role).to.be.eq(\"provider\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -13176,7 +12950,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13221,7 +12995,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"ri:8eed51c0-bc79-4cdd-af72-521e8dd37020\");",
 											"    pm.expect(result.role).to.be.eq(\"provider\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -13261,200 +13035,6 @@
 										"auth",
 										"v1",
 										"introspect"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Provider role - get catalogue token - [200]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    const moment = require('moment');",
-											"",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
-											"    const result = body.results;",
-											"    pm.expect(result).to.have.property(\"accessToken\");",
-											"    pm.expect(result.expiry).to.be.greaterThan(moment().unix());",
-											"    pm.expect(result.server).to.be.eq(\"cat-test.iudx.io\");",
-											"",
-											"    pm.environment.set(\"INTROSPECT_TOKEN\", result.accessToken);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Introspect Provider-catalogue token - [200]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    const moment = require('moment');",
-											"",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
-											"    const result = body.results;",
-											"    pm.expect(result).to.have.property(\"sub\");",
-											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
-											"    pm.expect(result.aud).to.be.eq(\"cat-test.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\");",
-											"    pm.expect(result.role).to.be.eq(\"provider\");",
-											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
-											"    pm.expect(result.cons).to.be.empty;",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{AUTH_ADMIN_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"accessToken\" : \"{{INTROSPECT_TOKEN}}\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/introspect",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"introspect"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "TEST CATALOGUE FLOW FOR NEW PROVIDER - [200]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    const moment = require('moment');",
-											"",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
-											"    const result = body.results;",
-											"    pm.expect(result).to.have.property(\"accessToken\");",
-											"    pm.expect(result.expiry).to.be.greaterThan(moment().unix());",
-											"    pm.expect(result.server).to.be.eq(\"cat-test.iudx.io\");",
-											"",
-											"    pm.environment.set(\"INTROSPECT_TOKEN\", result.accessToken);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{POSTMAN_PROVIDER_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"provider\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
 									]
 								}
 							},
@@ -13508,7 +13088,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13553,7 +13133,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.not.be.empty;",
@@ -13640,7 +13220,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13685,7 +13265,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"ri:8eed51c0-bc79-4cdd-af72-521e8dd37020\");",
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.not.be.empty;",
@@ -13770,7 +13350,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13815,7 +13395,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -13900,7 +13480,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -13945,7 +13525,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"ri:7f333829-6ed7-4e9e-93d8-e12958f7a535\");",
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.not.be.empty;",
@@ -14023,7 +13603,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14089,7 +13669,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14150,7 +13730,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14219,7 +13799,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14264,7 +13844,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 											"    pm.expect(result.role).to.be.eq(\"consumer\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.not.be.empty;",
@@ -14346,7 +13926,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14407,7 +13987,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14463,7 +14043,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14519,7 +14099,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14580,7 +14160,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14636,63 +14216,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delegate cannot get catalogue token - [403]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(403);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -16739,7 +16263,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -16784,7 +16308,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 											"    pm.expect(result.role).to.be.eq(\"delegate\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -16865,7 +16389,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -16910,7 +16434,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\");",
+											"    pm.expect(result.iid).to.be.eq(\"ri:7f333829-6ed7-4e9e-93d8-e12958f7a535\");",
 											"    pm.expect(result.role).to.be.eq(\"delegate\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -16995,7 +16519,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -17040,7 +16564,7 @@
 											"    pm.expect(result).to.have.property(\"sub\");",
 											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 											"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\");",
+											"    pm.expect(result.iid).to.be.eq(\"ri:2923c77f-741b-4c3a-b010-183efbd43dee\");",
 											"    pm.expect(result.role).to.be.eq(\"delegate\");",
 											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 											"    pm.expect(result.cons).to.be.empty;",
@@ -17062,130 +16586,6 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n    \"accessToken\" : \"{{INTROSPECT_TOKEN}}\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/introspect",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"introspect"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delegate can get catalogue token - [200]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    const moment = require('moment');",
-											"",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
-											"    const result = body.results;",
-											"    pm.expect(result).to.have.property(\"accessToken\");",
-											"    pm.expect(result.expiry).to.be.greaterThan(moment().unix());",
-											"    pm.expect(result.server).to.be.eq(\"cat-test.iudx.io\");",
-											"",
-											"    pm.environment.set(\"CAT_TOKEN\", result.accessToken);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{REJPROVIDER_DELEGATE_TOKEN}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\",\n    \"itemType\": \"resource\",\n    \"role\": \"delegate\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{AUTH_ENDPOINT}}/auth/v1/token",
-									"host": [
-										"{{AUTH_ENDPOINT}}"
-									],
-									"path": [
-										"auth",
-										"v1",
-										"token"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Introspect delegate-cat token - [200]",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Response status\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
-											"pm.test(\"Check response header\", function () {",
-											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");",
-											"});",
-											"",
-											"pm.test(\"Check response body\", function () {    ",
-											"    const body = pm.response.json();",
-											"    const moment = require('moment');",
-											"",
-											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
-											"    const result = body.results;",
-											"    pm.expect(result).to.have.property(\"sub\");",
-											"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
-											"    pm.expect(result.aud).to.be.eq(\"cat-test.iudx.io\");",
-											"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/cat-test.iudx.io/catalogue/crud\");",
-											"    pm.expect(result.role).to.be.eq(\"delegate\");",
-											"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
-											"    pm.expect(result.cons).to.be.empty;",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"accessToken\" : \"{{CAT_TOKEN}}\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -17242,7 +16642,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
+									"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"delegate\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -18250,7 +17650,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -19288,7 +18688,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two-fake\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e-fake\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -19347,7 +18747,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n                {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n                {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -19389,7 +18789,7 @@
 									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
 									"    pm.expect(body.results).to.not.be.empty;",
 									"    pm.expect(body.results[0]).to.have.property(\"requestId\");",
-									"    pm.expect(body.results[0]).to.have.property(\"itemId\",\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\" );",
+									"    pm.expect(body.results[0]).to.have.property(\"itemId\",\"aec83a80-61ec-4ae0-8671-80194f2ce73e\" );",
 									"    pm.expect(body.results[0]).to.have.property(\"itemType\",\"resource_group\" );",
 									"        pm.expect(body.results[0].user).to.not.be.empty;",
 									"        pm.expect(body.results[0].owner).to.not.be.empty;",
@@ -19415,7 +18815,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P20Y\",\n            \"constraints\": {}\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y2M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\",\n                    \"sub\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P20Y\",\n            \"constraints\": {}\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -19474,7 +18874,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P5Y\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P5Y\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y4M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"220c1911-3cdb-4012-bbcc-c5a223a12626\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P5Y\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P5Y\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"expiryDuration\": \"P1Y4M10DT2H30M\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -19516,7 +18916,7 @@
 									"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:Success\");",
 									"    pm.expect(body.results).to.not.be.empty;",
 									"    pm.expect(body.results[0]).to.have.property(\"requestId\");",
-									"    pm.expect(body.results[0]).to.have.property(\"itemId\",\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\" );",
+									"    pm.expect(body.results[0]).to.have.property(\"itemId\",\"7f333829-6ed7-4e9e-93d8-e12958f7a535\" );",
 									"    pm.expect(body.results[0]).to.have.property(\"itemType\",\"resource\" );",
 									"        pm.expect(body.results[0].user).to.not.be.empty;",
 									"        pm.expect(body.results[0].owner).to.not.be.empty;",
@@ -19542,7 +18942,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P1Y\",\n            \"constraints\": {\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n            \"itemType\": \"resource\",\n            \"expiryDuration\": \"P1Y\",\n            \"constraints\": {\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -24378,7 +23778,7 @@
 											"            pm.expect(r.owner.id == \"746442f5-18a7-44fd-8c8f-3e39e5026fae\").to.be.true;",
 											"            pm.expect(r.user.id).to.be.eq(pm.environment.get(\"CONSUMER_GMAIL_USERID\"));",
 											"            pm.expect(r.user.email).to.be.eq(\"consumer@gmail.com\");",
-											"            pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+                                            "            pm.expect(r.itemId).to.exist;",
 											"            pm.expect(r.constraints).to.exist;",
 											"            pm.expect(r.policyId).to.exist;",
 											"            pm.expect(r.expiryTime).to.exist;",
@@ -24510,7 +23910,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"userClass\":\"userClass\",\n            \"apdId\": 123,\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"userClass\":\"userClass\",\n            \"apdId\": 123,\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -24566,7 +23966,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"userClass\":\"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"userClass\":\"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -24622,7 +24022,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"userId\": \"this should not be here\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"userId\": \"this should not be here\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -24678,7 +24078,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"userId\": \"this should not be here\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"userId\": \"this should not be here\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -24734,7 +24134,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/????\",\n            \"itemType\": \"resource\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8/????\",\n            \"itemType\": \"resource\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25014,7 +24414,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25070,7 +24470,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": []\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\":\"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": []\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25126,7 +24526,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"?\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"?\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25182,7 +24582,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25238,7 +24638,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {},\n            \"expiryTime\": \"2133231-23-232T90320\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {},\n            \"expiryTime\": \"2133231-23-232T90320\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25294,7 +24694,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"2923c77f-741b-4c3a-b010-183efbd43dee\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"example.com\",\n            \"userClass\": \"userClass\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -25929,7 +25329,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"activeapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"activeapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26042,7 +25442,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"pendingapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"pendingapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26098,7 +25498,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"inactiveapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"inactiveapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26154,7 +25554,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"nonexistentapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"nonexistentapd.integration-iudx.io\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26193,7 +25593,7 @@
 											"pm.test(\"Check response body\", function () {    ",
 											"    const body = pm.response.json();",
 											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:as:InvalidInput\");",
-											"    pm.expect(body).to.have.property(\"title\",\"Item does not exist\");",
+											"    pm.expect(body).to.have.property(\"title\",\"Invalid Item ID format\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -26211,7 +25611,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a5dandjns05/rs.iudx.io/iasd\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a5dandjns05/rs.iudx.io/iasd\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26267,7 +25667,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a5dandjns05/rs.iudx.io/iasd\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a5dandjns05/rs.iudx.io/iasd\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26324,7 +25724,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/9c13a2308bb0919bf146be8681eb886922d29282/rs.iudx.io/invalid-resource-for-ownership-test\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"decffa8a-a1ec-3a60-e571-cafedead5351\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26381,7 +25781,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26438,7 +25838,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"activeapd.integration-iudx.io\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"activeapd.integration-iudx.io\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26495,7 +25895,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-01-01T01:01:01\"\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-01T01:01:01\"\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-01-01T01:01:01\"\n        },\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            },\n            \"expiryTime\": \"2030-12-01T01:01:01\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26551,7 +25951,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"constraints\": {\n                \"access\": [\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n        {\n            \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n            \"itemType\": \"resource\",\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"constraints\": {\n                \"access\": [\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26618,7 +26018,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/9c13a2308bb0919bf146be8681eb886922d29282/rs.iudx.io/invalid-resource-for-ownership-test\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"decffa8a-a1ec-3a60-e571-cafedead5351\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26679,7 +26079,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n         {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-two\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDenyNInteraction\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDeny\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        },\n         {\n            \"itemId\": \"220c1911-3cdb-4012-bbcc-c5a223a12626\",\n            \"itemType\": \"resource\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestDenyNInteraction\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -26750,7 +26150,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -26795,7 +26195,7 @@
 									"    pm.expect(result).to.have.property(\"sub\");",
 									"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 									"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-									"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\");",
+									"    pm.expect(result.iid).to.be.eq(\"rg:4b367af2-ad55-4017-9e19-35a5fa37e9b8\");",
 									"    pm.expect(result.role).to.be.eq(\"consumer\");",
 									"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 									"    pm.expect(result.cons).to.not.be.empty;",
@@ -26882,7 +26282,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"8eed51c0-bc79-4cdd-af72-521e8dd37020\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -26927,7 +26327,7 @@
 									"    pm.expect(result).to.have.property(\"sub\");",
 									"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 									"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-									"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one/test-resource-one\");",
+									"    pm.expect(result.iid).to.be.eq(\"ri:8eed51c0-bc79-4cdd-af72-521e8dd37020\");",
 									"    pm.expect(result.role).to.be.eq(\"consumer\");",
 									"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 									"    pm.expect(result.cons).to.not.be.empty;",
@@ -27006,7 +26406,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27065,7 +26465,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27132,7 +26532,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-two\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"220c1911-3cdb-4012-bbcc-c5a223a12626\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27259,7 +26659,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-one\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": {\n        \"accessType\": \"SOME_ACCESS_TYPE\",\n        \"accessId\": 1234,\n        \"accessList\": [\n            123,\n            \"2\",\n            {\n                \"list\": \"four\"\n            }\n        ],\n        \"accessObject\": {\n            \"access\": \"Y\"\n        }\n    }\n}",
+							"raw": "{\n    \"itemId\": \"4b367af2-ad55-4017-9e19-35a5fa37e9b8\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\",\n    \"context\": {\n        \"accessType\": \"SOME_ACCESS_TYPE\",\n        \"accessId\": 1234,\n        \"accessList\": [\n            123,\n            \"2\",\n            {\n                \"list\": \"four\"\n            }\n        ],\n        \"accessObject\": {\n            \"access\": \"Y\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27320,7 +26720,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"apdId\": \"{{TEST_APD_URL}}\",\n            \"userClass\": \"TestAllow\",\n            \"constraints\": {\n                \"access\": [\n                    \"api\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27384,7 +26784,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27429,7 +26829,7 @@
 									"    pm.expect(result).to.have.property(\"sub\");",
 									"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 									"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-									"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\");",
+									"    pm.expect(result.iid).to.be.eq(\"rg:aec83a80-61ec-4ae0-8671-80194f2ce73e\");",
 									"    pm.expect(result.role).to.be.eq(\"consumer\");",
 									"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 									"    pm.expect(result.cons).to.not.be.empty;",
@@ -27508,7 +26908,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n            \"itemType\": \"resource_group\",\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"constraints\": {\n                \"access\": [\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request\": [\n        {\n            \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n            \"itemType\": \"resource_group\",\n            \"userId\": \"{{CONSUMER_GMAIL_USERID}}\",\n            \"constraints\": {\n                \"access\": [\n                    \"sub\"\n                ]\n            }\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27572,7 +26972,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"aec83a80-61ec-4ae0-8671-80194f2ce73e\",\n    \"itemType\": \"resource_group\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27617,7 +27017,7 @@
 									"    pm.expect(result).to.have.property(\"sub\");",
 									"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 									"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-									"    pm.expect(result.iid).to.be.eq(\"rg:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two\");",
+									"    pm.expect(result.iid).to.be.eq(\"rg:aec83a80-61ec-4ae0-8671-80194f2ce73e\");",
 									"    pm.expect(result.role).to.be.eq(\"consumer\");",
 									"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 									"    pm.expect(result.cons).to.not.be.empty;",
@@ -27704,7 +27104,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\n    \"itemId\": \"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
+							"raw": "{\n\n    \"itemId\": \"7f333829-6ed7-4e9e-93d8-e12958f7a535\",\n    \"itemType\": \"resource\",\n    \"role\": \"consumer\"\n\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -27749,7 +27149,7 @@
 									"    pm.expect(result).to.have.property(\"sub\");",
 									"    pm.expect(result.iss).to.be.eq(\"authorization.iudx.io\");",
 									"    pm.expect(result.aud).to.be.eq(\"rs.iudx.io\");",
-									"    pm.expect(result.iid).to.be.eq(\"ri:datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/rs.iudx.io/integration-test-rsg-two/test-resource-one\");",
+									"    pm.expect(result.iid).to.be.eq(\"ri:7f333829-6ed7-4e9e-93d8-e12958f7a535\");",
 									"    pm.expect(result.role).to.be.eq(\"consumer\");",
 									"    pm.expect(result.exp).to.be.greaterThan(moment().unix());",
 									"    pm.expect(result.cons).to.not.be.empty;",
@@ -27886,7 +27286,7 @@
 									"            pm.expect(r.owner.id == \"746442f5-18a7-44fd-8c8f-3e39e5026fae\").to.be.true;",
 									"            pm.expect(r.user.id).to.be.eq(pm.environment.get(\"CONSUMER_GMAIL_USERID\"));",
 									"            pm.expect(r.user.email).to.be.eq(\"consumer@gmail.com\");",
-									"            pm.expect(r.itemId.startsWith(\"datakaveri.org/0808eb81ea0e5773187ae06110f55915a55f5c05/\")).to.be.true;",
+									"            pm.expect(r.itemId).to.exist;",
 									"            pm.expect(r.constraints).to.exist;",
 									"            pm.expect(r.policyId).to.exist;",
 									"            pm.expect(r.expiryTime).to.exist;",


### PR DESCRIPTION

- The UUID representation of the catalogue item are the internal UUIDs that the AAA server generates in its `resource_group` and `resource` tables

Affected APIs
-------------
- Create Policy
- List Policy
	- in response
- Create Token
- Introspect Token
	- in response
- Create Notification
- Update Notification
	- in response
- Withdraw Notification
	- in response
- List Notification
	- in response

Breaking Changes
----------------
- Catalogue fetch is disabled, new resource groups/resources cannot be queried from the catalogue
	- Policies, notifications and tokens will only work with resources/resource groups present in the AAA DB
- Catalogue onboarding token cannot be obtained anymore

`CatalogueClient`, `policy/Constants`
-------------------------------------
- Add UUID check for item IDs
- Update queries to `resource`, `resource_group` to query by `id` instead of `cat_id`
- Disable catalogue fetch

`PolicyServiceImpl`
-------------------
- Remove any split-item-ID-by-'/' checks
- Remove email hash checks
- Remove calls to get cat-ID given cat-UUID from DB
- Remove catalogue onboard token flow

Tests
-----
- Disable unnecessary tests
- Update tests to stop using email-SHA based cat IDs

`TestRequest`
------------
- Update email-SHA cat IDs to UUIDs for test data that is present in DB

`Integration_Test` Postman Collection
-------------------------------------
- Update email-SHA cat IDs to UUIDs
- Remove catalogue onboarding token tests

Jenkinsfile
-----------
- Increase threshold for skipped tests

OpenAPI spec
------------
- Update docs for affected APIs