### PR TITLE
Bug-Fix: Fix auditing read query test

### DIFF
--- a/src/test/java/iudx/aaa/server/auditing/AuditingServiceTest.java
+++ b/src/test/java/iudx/aaa/server/auditing/AuditingServiceTest.java
@@ -163,7 +163,7 @@ public class AuditingServiceTest {
     jsonObject.put("userId", "/userId");
     jsonObject.put("method", "POST");
     jsonObject.put("endPoint", "/post");
-    jsonObject.put("startTime", "1970-01-01T05:30:00+05:30[Asia/Kolkata]");
+    jsonObject.put("startTime", ZonedDateTime.now().minusSeconds(5).toString());
     jsonObject.put("endTime", ZonedDateTime.now().toString());
     return jsonObject;
   }
@@ -176,12 +176,14 @@ public class AuditingServiceTest {
      * any point of time)
      */
     JsonObject dataToWrite = writeRequest();
-    JsonObject jsonObject = readRequest();
 
     Promise<JsonObject> promise = Promise.promise();
     auditingService.executeWriteQuery(dataToWrite, promise);
 
     promise.future().onComplete(written -> {
+      // create readRequest here so that query endTime is 
+      // only after the write is done 
+      JsonObject jsonObject = readRequest();
       auditingService.executeReadQuery(jsonObject,
           vertxTestContext.succeeding(response -> vertxTestContext.verify(() -> {
             


### PR DESCRIPTION
- The previous read query was getting too much data so it was failing
- Updated the test to query for data inserted in last 5 seconds
- Cherry-picked from `main` - 6b6ab52e01695225c4a72ccf8f17bacee0fe5552