### PR TITLE
Stop writing realm roles back to Keycloak on user profile creation/updation and provider approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The AAA server uses [Keycloak](https://www.keycloak.org/about.html) to manage us
 
 1. The AAA server required clients to be configured that would allow the server to interact with Keycloak. The main clients are:
 
-- The **admin client** to be configured for the `RegistrationVerticle` and `AdminVerticle`. This client performs admin-related tasks on Keycloak. This client must have the capability to view and update users and realms (In Service account roles -> client roles -> realm-management -> _add manage-users_, _view-realm_, _view-users_ to Assigned roles) 
+- The **admin client** to be configured for the `RegistrationVerticle` and `AdminVerticle`. This client performs admin-related tasks on Keycloak. This client must have the capability to view and update users and realms (In Service account roles -> client roles -> realm-management -> add _view-users_ to Assigned roles) 
 - The **normal client** to be configured for the `TokenVerticle` and `ApiServerVerticle`. This client would allow the server to validate Keycloak JWT tokens.
 
 2. The roles `provider`, `consumer`, `delegate` and `admin` need to be added to the realm.

--- a/src/main/java/iudx/aaa/server/admin/AdminServiceImpl.java
+++ b/src/main/java/iudx/aaa/server/admin/AdminServiceImpl.java
@@ -247,11 +247,6 @@ public class AdminServiceImpl implements AdminService {
         request.stream().filter(obj -> obj.getStatus().equals(RoleStatus.APPROVED))
             .map(obj -> UUID.fromString(obj.getUserId())).collect(Collectors.toList());
 
-    /* Function to get Keycloak IDs of approved providers */
-    Function<Map<UUID, UUID>, List<String>> getKcIdToApprove = (map) -> {
-      return toBeApproved.stream().map(uid -> map.get(uid).toString()).collect(Collectors.toList());
-    };
-
     /* Function to get Keycloak IDs of all providers in request */
     Function<Map<UUID, UUID>, List<String>> getKcIds = (map) -> {
       return ids.stream().map(uid -> map.get(uid).toString()).collect(Collectors.toList());
@@ -263,8 +258,7 @@ public class AdminServiceImpl implements AdminService {
 
     Future<Map<String, JsonObject>> result = checkRes
         .compose(uidToKc -> pool.withTransaction(conn -> conn.preparedQuery(SQL_UPDATE_ROLE_STATUS)
-            .executeBatch(tuple).compose(cc -> kc.approveProvider(getKcIdToApprove.apply(uidToKc)))
-            .compose(success -> setAuthAdminPolicy(user, toBeApproved))
+            .executeBatch(tuple).compose(success -> setAuthAdminPolicy(user, toBeApproved))
             .compose(r -> kc.getDetails(getKcIds.apply(uidToKc)))));
 
     result.onSuccess(details -> {

--- a/src/test/java/iudx/aaa/server/admin/UpdateProviderRegistrationStatusTest.java
+++ b/src/test/java/iudx/aaa/server/admin/UpdateProviderRegistrationStatusTest.java
@@ -336,7 +336,7 @@ public class UpdateProviderRegistrationStatusTest {
         new JsonObject().put("userId", providerJson.getString("userId")).put("status", "approved"));
     List<ProviderUpdateRequest> request = ProviderUpdateRequest.jsonArrayToList(req);
 
-    /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
+    /** MOCKS -> mock PolicyService, kc.getDetails **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(3);
       p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
@@ -348,8 +348,6 @@ public class UpdateProviderRegistrationStatusTest {
     Mockito.when(kc.getDetails(any())).thenReturn(Future.succeededFuture(resp));
     Mockito.when(resp.get(anyString())).thenReturn(new JsonObject());
     Mockito.when(resp.get(providerJson.getString("keycloakId"))).thenReturn(details);
-
-    Mockito.when(kc.approveProvider(any())).thenReturn(Future.succeededFuture());
     /***********************************************************************/
 
     adminService.updateProviderRegistrationStatus(request, user,
@@ -390,7 +388,7 @@ public class UpdateProviderRegistrationStatusTest {
         new JsonObject().put("userId", providerJson.getString("userId")).put("status", "approved"));
     List<ProviderUpdateRequest> request = ProviderUpdateRequest.jsonArrayToList(req);
 
-    /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
+    /** MOCKS -> mock PolicyService, kc.getDetails **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(3);
       p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
@@ -402,8 +400,6 @@ public class UpdateProviderRegistrationStatusTest {
     Mockito.when(kc.getDetails(any())).thenReturn(Future.succeededFuture(resp));
     Mockito.when(resp.get(anyString())).thenReturn(new JsonObject());
     Mockito.when(resp.get(providerJson.getString("keycloakId"))).thenReturn(details);
-
-    Mockito.when(kc.approveProvider(any())).thenReturn(Future.succeededFuture());
     /***********************************************************************/
 
     adminService.updateProviderRegistrationStatus(request, user,
@@ -432,7 +428,7 @@ public class UpdateProviderRegistrationStatusTest {
         new JsonObject().put("userId", providerJson.getString("userId")).put("status", "rejected"));
     List<ProviderUpdateRequest> request = ProviderUpdateRequest.jsonArrayToList(req);
 
-    /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
+    /** MOCKS -> mock PolicyService, kc.getDetails **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(3);
       p.complete(new JsonObject().put("type", URN_SUCCESS.toString()));
@@ -444,8 +440,6 @@ public class UpdateProviderRegistrationStatusTest {
     Mockito.when(kc.getDetails(any())).thenReturn(Future.succeededFuture(resp));
     Mockito.when(resp.get(anyString())).thenReturn(new JsonObject());
     Mockito.when(resp.get(providerJson.getString("keycloakId"))).thenReturn(details);
-
-    Mockito.when(kc.approveProvider(any())).thenReturn(Future.succeededFuture());
     /***********************************************************************/
 
     Checkpoint rejected = testContext.checkpoint();
@@ -501,7 +495,7 @@ public class UpdateProviderRegistrationStatusTest {
         new JsonObject().put("userId", providerJson.getString("userId")).put("status", "approved"));
     List<ProviderUpdateRequest> request = ProviderUpdateRequest.jsonArrayToList(req);
 
-    /** MOCKS -> mock PolicyService, kc.getDetails and kc.approveProvider **/
+    /** MOCKS -> mock PolicyService, kc.getDetails **/
     Mockito.doAnswer(i -> {
       Promise<JsonObject> p = i.getArgument(3);
       p.fail("Failed to set admin ");
@@ -513,8 +507,6 @@ public class UpdateProviderRegistrationStatusTest {
     Mockito.when(kc.getDetails(any())).thenReturn(Future.succeededFuture(resp));
     Mockito.when(resp.get(anyString())).thenReturn(new JsonObject());
     Mockito.when(resp.get(providerJson.getString("keycloakId"))).thenReturn(details);
-
-    Mockito.when(kc.approveProvider(any())).thenReturn(Future.succeededFuture());
     /***********************************************************************/
 
     Checkpoint failed = testContext.checkpoint();

--- a/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
+++ b/src/test/java/iudx/aaa/server/registration/CreateUserTest.java
@@ -158,7 +158,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -201,7 +200,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq = new JsonObject().put("roles", new JsonArray().add("provider"))
@@ -244,7 +242,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -287,7 +284,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -330,7 +326,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq = new JsonObject()
@@ -379,7 +374,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -405,7 +399,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -431,7 +424,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -458,7 +450,6 @@ public class CreateUserTest {
     String orgId = orgIdFut.result().toString();
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture("random@email.com"));
 
     JsonObject jsonReq =
@@ -485,7 +476,6 @@ public class CreateUserTest {
     String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
 
     JsonObject jsonReq =
@@ -522,7 +512,6 @@ public class CreateUserTest {
     String orgId = orgIdFut.result().toString();
     String keycloakId = UUID.randomUUID().toString();
 
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
     Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(""));
 
     JsonObject jsonReq =
@@ -539,38 +528,5 @@ public class CreateUserTest {
           assertEquals(ERR_TITLE_USER_NOT_KC, response.getString("title"));
           testContext.completeNow();
         })));
-  }
-
-  @Test
-  @DisplayName("Test transaction rollback if Keycloak fails")
-  void modifyRolesFail(VertxTestContext testContext) {
-
-    String email = RandomStringUtils.randomAlphabetic(5).toLowerCase() + "@" + url;
-    String keycloakId = UUID.randomUUID().toString();
-
-    Mockito.when(kc.getEmailId(any())).thenReturn(Future.succeededFuture(email));
-    Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.failedFuture("fail"));
-
-    JsonObject jsonReq = new JsonObject().put("roles", new JsonArray().add("consumer"));
-    RegistrationRequest request = new RegistrationRequest(jsonReq);
-
-    User user = new UserBuilder().keycloakId(keycloakId).name("Foo", "Bar").build();
-
-    Promise<Void> failed = Promise.promise();
-    registrationService.createUser(request, user,
-        testContext.failing(response -> testContext.verify(() -> {
-          failed.complete();
-        })));
-
-    failed.future().onSuccess(i -> {
-      Mockito.when(kc.modifyRoles(any(), any())).thenReturn(Future.succeededFuture());
-
-      registrationService.createUser(request, user,
-          testContext.succeeding(response -> testContext.verify(() -> {
-            assertEquals(URN_SUCCESS.toString(), response.getString("type"));
-            assertEquals(201, response.getInteger("status"));
-            testContext.completeNow();
-          })));
-    });
   }
 }


### PR DESCRIPTION
(Cherry-picked from df2f1d9cfd81b61f9ac80e2580fdbc7ea1b5fe2d)
- We can now lower privileges of the `keycloak-admin` client that is configured during set up
- Updated KcAdmin and Registration, Admin verticles + tests
- Updated setup in README