### PR TITLE
Update Keycloak dependency to 22.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,7 @@
 		<maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
         <spotless.version>2.31.0</spotless.version>
 		<openjdk.version>11</openjdk.version>
-		<keycloak.version>18.0.1</keycloak.version>
-		<resteasy.version>3.13.2.Final</resteasy.version>
+		<keycloak.version>22.0.1</keycloak.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<exec.mainClass>iudx.aaa.server.deploy.Deployer</exec.mainClass>
 		<exec.mainClassDev>iudx.aaa.server.deploy.DeployerDev
@@ -131,17 +130,6 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.58</version>
     </dependency>
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-client</artifactId>
-			<version>${resteasy.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jackson2-provider</artifactId>
-			<version>${resteasy.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-unit</artifactId>

--- a/src/main/java/iudx/aaa/server/registration/KcAdmin.java
+++ b/src/main/java/iudx/aaa/server/registration/KcAdmin.java
@@ -6,9 +6,10 @@ import io.vertx.core.json.JsonObject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ProcessingException;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
@@ -41,10 +42,16 @@ public class KcAdmin {
   public KcAdmin(String serverUrl, String realm, String clientId, String clientSecret,
       int poolSize) {
 
+    /* NOTE: Not sure if it's 'correct' to use ResteasyClientBuilderImpl, but there doesn't seem to
+     * be any other way to get the connectionPoolSize option using this.
+     * 
+     *  See here - https://stackoverflow.com/a/65853591
+     */
+    ResteasyClient client = new ResteasyClientBuilderImpl().connectionPoolSize(poolSize).build();
     this.realm = realm;
     keycloak = KeycloakBuilder.builder().serverUrl(serverUrl).realm(realm)
-        .grantType(OAuth2Constants.CLIENT_CREDENTIALS).clientId(clientId).clientSecret(clientSecret)
-        .resteasyClient(new ResteasyClientBuilder().connectionPoolSize(poolSize).build()).build();
+        .grantType(OAuth2Constants.CLIENT_CREDENTIALS).clientId(clientId).clientSecret(clientSecret).resteasyClient(client)
+        .build();
   }
 
   /**

--- a/src/main/resources/postman/IUDX-AAA-Server.postman_collection.json
+++ b/src/main/resources/postman/IUDX-AAA-Server.postman_collection.json
@@ -47,7 +47,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -136,7 +136,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -245,7 +245,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -441,7 +441,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -531,7 +531,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -645,7 +645,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -812,7 +812,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -916,7 +916,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1029,7 +1029,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1145,7 +1145,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1244,7 +1244,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1408,7 +1408,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1507,7 +1507,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1604,7 +1604,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1709,7 +1709,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1806,7 +1806,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{
@@ -1895,7 +1895,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "email",
+									"value": "email openid",
 									"type": "string"
 								},
 								{


### PR DESCRIPTION
- Remove RESTeasy dependencies from POM
	- Use whatever version `keycloak-admin-client` is using
- Using the Jakarta EE version of the `keycloak-admin-client`
- Using `ResteasyClientBuilderImpl` to create a client w/ connection pool
	- Some say that it's not meant to be used because it's internal
	- not sure what to do
- Scope `openid` needs to be added whenever getting a token from Keycloak in order for userinfo flow to work