### PR TITLE
Add Authorization header parameter explicitly in APD APIs spec (main branch)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3063,6 +3063,16 @@ paths:
         Returns registered APDs. 
         - If called by the COS Admin, returns all APD registrations
         - If called by a user with any other roles, returns all APDs in the **active** state
+      parameters:
+        - schema:
+            type: string
+            maxLength: 4000
+            minLength: 1
+            example: Bearer <JWT>
+          in: header
+          name: Authorization
+          description: Keycloak Issued token
+          required: true
       security:
         - authorization: []
       tags:
@@ -3211,6 +3221,16 @@ paths:
 
       security:
         - authorization: []
+      parameters:
+        - schema:
+            type: string
+            maxLength: 4000
+            minLength: 1
+            example: Bearer <JWT>
+          in: header
+          name: Authorization
+          description: Keycloak Issued token
+          required: true
       requestBody:
         content:
           application/json:
@@ -3396,7 +3416,16 @@ paths:
         The COS Admin may change status :
         - from **active** to **inactive**, in case the APD is not responsive or has been compromised
         - from **inactive** to **active**
-
+      parameters:
+        - schema:
+            type: string
+            maxLength: 4000
+            minLength: 1
+            example: Bearer <JWT>
+          in: header
+          name: Authorization
+          description: Keycloak Issued token
+          required: true
       requestBody:
         required: true
         content:


### PR DESCRIPTION
- Using `security` in the API spec is more than enough and OAS validation will check for presence of the authorization header with that
- But all other APIs that take tokens have the Authorization header parameter defined explicitly including the `security` option
- So only adding this for uniformity