### PR TITLE
Github Actions: Automatic image tag updates

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-# This github workflow will automatically update docker image tags of aaa-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/aaa-depl .Based on tag it will update the master/latest branch (if its 5.0.0-alpha-) or 4.5.0 stable branch (if its 4.5.0-)
+# This github workflow will automatically update docker image tags of aaa-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/aaa-depl .Based on tag it will update the master/latest branch (if its 5.5.1-alpha-) or 5.5.0 stable branch (if its 5.5.0-)
 name: Update AAA docker image tags
 
 # This trigger will run the workflow whenever a new package is published to the registry
@@ -28,14 +28,14 @@ jobs:
       env: 
         GH_TOKEN: ${{ secrets.JENKINS_UPDATE}}
       run: | 
-        # Get the latest version of 4.5.0 and 5.0.0-alpha tags from the container registry using GitHub API
-        export newtag4_5_0=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 4.5.0 | sed -e 's/^"//' -e 's/"$//'))`
-        export newtag5_0_0=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.0.0-alpha | sed -e 's/^"//' -e 's/"$//'))`
+        # Get the latest version of 5.5.0 and 5.5.1-alpha tags from the container registry using GitHub API
+        export newtag5_5_0=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))`
+        export newtag5_5_1=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.1 | sed -e 's/^"//' -e 's/"$//'))`
         
         # Get the old tags from the YAML files
-        export oldtag5_0_0=`yq -r .services.auth.image Docker-Swarm-deployment/single-node/auth/auth-stack.yaml | cut -d : -f 2`
-        git checkout 4.5.0
-        export oldtag4_5_0=$(yq -r .services.auth.image Docker-Swarm-deployment/single-node/auth/auth-stack.yaml | cut -d : -f 2)      
+        export oldtag5_5_1=`yq -r .services.auth.image Docker-Swarm-deployment/single-node/auth/auth-stack.yaml | cut -d : -f 2`
+        git checkout 5.5.0
+        export oldtag5_5_0=$(yq -r .services.auth.image Docker-Swarm-deployment/single-node/auth/auth-stack.yaml | cut -d : -f 2)      
         
         # Set Git user
         git config --global user.name 'jenkins-datakaveri'
@@ -43,12 +43,12 @@ jobs:
 
 
         # Update the YAML files and create a new branch for each tag update
-        if [ "$newtag4_5_0" != "$oldtag4_5_0" ]
+        if [ "$newtag5_5_0" != "$oldtag5_5_0" ]
         then
-         git checkout -b aaa-4.5.0-automatic-updates/$newtag4_5_0
+         git checkout -b aaa-5.5.0-automatic-updates/$newtag5_5_0
 
-         # Uses sed to find and replace $oldtag4_5_0 with $newtag4_5_0 in Docker-Swarm-deployment/single-node/auth/auth-stack.yaml file
-         sed -i s/$oldtag4_5_0/$newtag4_5_0/g Docker-Swarm-deployment/single-node/auth/auth-stack.yaml
+         # Uses sed to find and replace $oldtag5_5_0 with $newtag5_5_0 in Docker-Swarm-deployment/single-node/auth/auth-stack.yaml file
+         sed -i s/$oldtag5_5_0/$newtag5_5_0/g Docker-Swarm-deployment/single-node/auth/auth-stack.yaml
          
          # Exports the current version of the application from K8s-deployment/Charts/auth/Chart.yaml file
          export oldappversion=`yq -r .version K8s-deployment/Charts/auth-server/Chart.yaml`
@@ -58,22 +58,22 @@ jobs:
          
          # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/auth/Chart.yaml and K8s-deployment/Charts/auth/values.yaml files
          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/auth-server/Chart.yaml
-         sed -i s/$oldtag4_5_0/$newtag4_5_0/g K8s-deployment/Charts/auth-server/values.yaml
+         sed -i s/$oldtag5_5_0/$newtag5_5_0/g K8s-deployment/Charts/auth-server/values.yaml
          git add Docker-Swarm-deployment/single-node/auth/auth-stack.yaml K8s-deployment/Charts/auth-server/values.yaml K8s-deployment/Charts/auth-server/Chart.yaml
-         git commit --allow-empty -m "updated AAA docker image tag to $newtag4_5_0"
-         git push --set-upstream origin aaa-4.5.0-automatic-updates/$newtag4_5_0
+         git commit --allow-empty -m "updated AAA docker image tag to $newtag5_5_0"
+         git push --set-upstream origin aaa-5.5.0-automatic-updates/$newtag5_5_0
          
-         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch 4.5.0
-         gh pr create -R datakaveri/iudx-deployment --base 4.5.0 --fill 
+         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch 5.5.0
+         gh pr create -R datakaveri/iudx-deployment --base 5.5.0 --fill 
         fi
         
-        if [ "$newtag5_0_0" != "$oldtag5_0_0" ]
+        if [ "$newtag5_5_1" != "$oldtag5_5_1" ]
         then
          git checkout master
-         git checkout -b aaa-automatic-updates/$newtag5_0_0
+         git checkout -b aaa-automatic-updates/$newtag5_5_1
 
-          # Uses sed to find and replace $oldtag5_0_0 with $newtag5_0_0 in Docker-Swarm-deployment/single-node/auth/auth-stack.yaml file
-         sed -i s/$oldtag5_0_0/$newtag5_0_0/g Docker-Swarm-deployment/single-node/auth/auth-stack.yaml
+          # Uses sed to find and replace $oldtag5_5_1 with $newtag5_5_1 in Docker-Swarm-deployment/single-node/auth/auth-stack.yaml file
+         sed -i s/$oldtag5_5_1/$newtag5_5_1/g Docker-Swarm-deployment/single-node/auth/auth-stack.yaml
 
          # Exports the current version of the application from K8s-deployment/Charts/auth/Chart.yaml file
          export oldappversion=`yq -r .version K8s-deployment/Charts/auth-server/Chart.yaml`
@@ -83,10 +83,10 @@ jobs:
          
          # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/auth/Chart.yaml and K8s-deployment/Charts/auth/values.yaml files
          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/auth-server/Chart.yaml
-         sed -i s/$oldtag5_0_0/$newtag5_0_0/g K8s-deployment/Charts/auth-server/values.yaml
+         sed -i s/$oldtag5_5_1/$newtag5_5_1/g K8s-deployment/Charts/auth-server/values.yaml
          git add Docker-Swarm-deployment/single-node/auth/auth-stack.yaml K8s-deployment/Charts/auth-server/values.yaml K8s-deployment/Charts/auth-server/Chart.yaml
-         git commit --allow-empty -m "updated AAA docker image tag to $newtag5_0_0"
-         git push --set-upstream origin aaa-automatic-updates/$newtag5_0_0
+         git commit --allow-empty -m "updated AAA docker image tag to $newtag5_5_1"
+         git push --set-upstream origin aaa-automatic-updates/$newtag5_5_1
 
          # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch master
          gh pr create -R datakaveri/iudx-deployment --base master --fill 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,7 +30,7 @@ jobs:
       run: | 
         # Get the latest version of 5.5.0 and 5.5.1-alpha tags from the container registry using GitHub API
         export newtag5_5_0=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))`
-        export newtag5_5_1=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.1 | sed -e 's/^"//' -e 's/"$//'))`
+        export newtag5_5_1=`(head -n 1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/aaa-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.1-alpha | sed -e 's/^"//' -e 's/"$//'))`
         
         # Get the old tags from the YAML files
         export oldtag5_5_1=`yq -r .services.auth.image Docker-Swarm-deployment/single-node/auth/auth-stack.yaml | cut -d : -f 2`


### PR DESCRIPTION
This github workflow will automatically update docker image tags of aaa-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/aaa-depl .Based on tag it will update the master/latest branch (if its 5.5.1-alpha-) or 5.5.0 stable branch (if its 5.5.0-)