### PR TITLE
Bug-Fix: Fix ComposeExceptionMessageCodec to include full Response object when decoded from event bus

### DIFF
--- a/src/main/java/iudx/aaa/server/apiserver/Response.java
+++ b/src/main/java/iudx/aaa/server/apiserver/Response.java
@@ -2,6 +2,7 @@ package iudx.aaa.server.apiserver;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apiserver.util.ComposeExceptionMessageCodec;
 import iudx.aaa.server.apiserver.util.Urn;
 
 /**
@@ -106,6 +107,46 @@ public class Response {
     }
 
     return j;
+  }
+
+  /**
+   * Convert JSON to Response object. Used for {@link ComposeExceptionMessageCodec} to form the
+   * {@link ComposeException} once it's sent on the wire.
+   *
+   * @return a {@link Response} object
+   */
+  public static Response fromJson(JsonObject j) {
+    ResponseBuilder builder = new ResponseBuilder();
+    
+    builder.type(j.getString("type"));
+    builder.title(j.getString("title"));
+    
+    Object results = j.getValue("results");
+
+    if (results != null && results instanceof JsonArray) {
+      builder.arrayResults((JsonArray) results);
+    }
+    
+    if (results != null && results instanceof JsonObject) {
+      builder.objectResults((JsonObject) results);
+    }
+
+    String detail = j.getString("detail");
+    if (detail != null) {
+      builder.detail(detail);
+    }
+
+    int status = j.getInteger("status");
+    if (status != 0) {
+      builder.status(status);
+    }
+
+    JsonObject errorContext = j.getJsonObject("context");
+    if (errorContext != null) {
+      builder.errorContext(errorContext);
+    }
+
+    return builder.build();
   }
 
   public String toJsonString() {

--- a/src/main/java/iudx/aaa/server/apiserver/util/ComposeExceptionMessageCodec.java
+++ b/src/main/java/iudx/aaa/server/apiserver/util/ComposeExceptionMessageCodec.java
@@ -3,6 +3,7 @@ package iudx.aaa.server.apiserver.util;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.json.JsonObject;
+import iudx.aaa.server.apiserver.Response;
 
 /**
  * Message codec for {@link iudx.aaa.server.apiserver.util.ComposeException}. This is used to decode
@@ -43,12 +44,7 @@ public class ComposeExceptionMessageCodec
     JsonObject contentJson = new JsonObject(jsonStr);
 
     // We can finally create custom message object
-    /* TODO: change this so that we use Response.fromJson() or something */
-    return new ComposeException(
-        contentJson.getInteger("status"),
-        contentJson.getString("type"),
-        contentJson.getString("title"),
-        contentJson.getString("detail"));
+    return new ComposeException(Response.fromJson(contentJson));
   }
 
   @Override


### PR DESCRIPTION
- When server was running in clustered mode, the `context` object was not getting passed in the response because it was not getting added to the ComposeException object when forming it once it came out of the event bus
- Added method in Response class to create a Response object from JSON, and using this method to recreate ComposeException properly