### PR TITLE
[5.6.0] Update OpenAPI spec - remove URL from production `servers` entry so that it uses the served URL in the Redoc rendered UI

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: For support contact DX Team at
     email: support@iudx.org.in
 servers:
-  - url: 'https://cos.iudx.org.in'
+  - url: ''
     description: Production
   - url: 'https://authvertx.iudx.io'
     description: Development


### PR DESCRIPTION

- Old URL was `cos.iudx.org.in`, but since the server is deployed in many different projects, it needs to reflect the actual URL
- Keeping it blank seems to work - Redoc handles it