### PR TITLE
Update OpenAPI - replace blank production URL with '/'

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: For support contact DX Team at
     email: support@iudx.org.in
 servers:
-  - url: ''
+  - url: '/'
     description: Production
   - url: 'https://authvertx.iudx.io'
     description: Development


### PR DESCRIPTION
- Blank URL was adding the `apis` path to the URL